### PR TITLE
feat: export index.css from @wallet-ui/react

### DIFF
--- a/examples/react-app/src/app/app-providers.tsx
+++ b/examples/react-app/src/app/app-providers.tsx
@@ -1,3 +1,5 @@
+import '@wallet-ui/react/index.css';
+
 import { clusterDevnet, clusterLocalnet, clusterTestnet, SolanaCluster, SolanaProvider } from '@wallet-ui/react';
 import { ReactNode } from 'react';
 import { BrowserRouter } from 'react-router-dom';

--- a/examples/react-app/src/features/dev/dev.tsx
+++ b/examples/react-app/src/features/dev/dev.tsx
@@ -1,6 +1,6 @@
 export default function Dev() {
     return (
-        <div>
+        <div className="wallet-ui-debug">
             <pre>{JSON.stringify({ page: 'DEV' }, null, 4)}</pre>
         </div>
     );

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -3,24 +3,27 @@
     "version": "1.0.0",
     "description": "React hooks for building Solana apps",
     "exports": {
-        "edge-light": {
-            "import": "./dist/index.node.mjs",
-            "require": "./dist/index.node.cjs"
+        ".": {
+            "edge-light": {
+                "import": "./dist/index.node.mjs",
+                "require": "./dist/index.node.cjs"
+            },
+            "workerd": {
+                "import": "./dist/index.node.mjs",
+                "require": "./dist/index.node.cjs"
+            },
+            "browser": {
+                "import": "./dist/index.browser.mjs",
+                "require": "./dist/index.browser.cjs"
+            },
+            "node": {
+                "import": "./dist/index.node.mjs",
+                "require": "./dist/index.node.cjs"
+            },
+            "react-native": "./dist/index.native.mjs",
+            "types": "./dist/types/index.d.ts"
         },
-        "workerd": {
-            "import": "./dist/index.node.mjs",
-            "require": "./dist/index.node.cjs"
-        },
-        "browser": {
-            "import": "./dist/index.browser.mjs",
-            "require": "./dist/index.browser.cjs"
-        },
-        "node": {
-            "import": "./dist/index.node.mjs",
-            "require": "./dist/index.node.cjs"
-        },
-        "react-native": "./dist/index.native.mjs",
-        "types": "./dist/types/index.d.ts"
+        "./index.css": "./dist/index.css"
     },
     "browser": {
         "./dist/index.node.cjs": "./dist/index.browser.cjs",

--- a/packages/react/src/index.css
+++ b/packages/react/src/index.css
@@ -1,0 +1,3 @@
+.wallet-ui-debug {
+    border: 1px solid red;
+}

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,3 +1,5 @@
+import './index.css';
+
 export * from './solana-client-context';
 export * from './solana-client-provider';
 export * from './solana-cluster-context';


### PR DESCRIPTION
This patch changes the exports of `@wallet-ui/react` so that it exports `index.css` that consumers of this package can import to get basic styling.