### PR TITLE
feat: expose selected cluster through useWalletUi hook

### DIFF
--- a/.changeset/social-dragons-throw.md
+++ b/.changeset/social-dragons-throw.md
@@ -1,0 +1,5 @@
+---
+'@wallet-ui/react': patch
+---
+
+expose selected cluster through useWalletUi hook

--- a/packages/playground-react/src/playground/account/wallet-ui-account-guard.tsx
+++ b/packages/playground-react/src/playground/account/wallet-ui-account-guard.tsx
@@ -7,7 +7,7 @@ export interface WalletUiAccountGuardProps {
 }
 
 export function WalletUiAccountGuard({ fallback = <WalletUiDropdown />, render }: WalletUiAccountGuardProps) {
-    const { account, accountKeys, wallet } = useWalletUiAccount();
+    const { account, accountKeys, cluster, wallet } = useWalletUiAccount();
 
-    return account ? render({ account, accountKeys, wallet }) : fallback;
+    return account ? render({ account, accountKeys, cluster, wallet }) : fallback;
 }

--- a/packages/react/src/wallet-ui-account-context-provider.tsx
+++ b/packages/react/src/wallet-ui-account-context-provider.tsx
@@ -7,10 +7,9 @@ import {
     uiWalletAccountsAreSame,
     useWallets,
 } from '@wallet-standard/react';
-import { createStorageAccount, StorageAccount } from '@wallet-ui/core';
+import { createStorageAccount, SolanaCluster, StorageAccount } from '@wallet-ui/core';
 import React, { useEffect, useMemo, useState } from 'react';
 
-import { useWalletUiCluster } from './use-wallet-ui-cluster';
 import { WalletUiAccountContext } from './wallet-ui-account-context';
 
 let wasSetterInvoked = false;
@@ -45,12 +44,13 @@ function getSavedWalletAccount(
  */
 export function WalletUiAccountContextProvider({
     children,
+    cluster,
     storage = createStorageAccount(),
 }: {
     children: React.ReactNode;
+    cluster: SolanaCluster;
     storage?: StorageAccount;
 }) {
-    const { cluster } = useWalletUiCluster();
     const wallets = useWallets();
     const accountId = useStore(storage.value);
     const [account, setAccountInternal] = useState<UiWalletAccount | undefined>(() =>
@@ -129,10 +129,11 @@ export function WalletUiAccountContextProvider({
                 () => ({
                     account: walletAccount,
                     accountKeys,
+                    cluster,
                     setAccount,
                     wallet,
                 }),
-                [walletAccount, wallet, accountKeys],
+                [accountKeys, cluster, wallet, walletAccount],
             )}
         >
             {children}

--- a/packages/react/src/wallet-ui-account-context.tsx
+++ b/packages/react/src/wallet-ui-account-context.tsx
@@ -1,9 +1,11 @@
 import { UiWallet, UiWalletAccount } from '@wallet-standard/react';
+import { SolanaCluster } from '@wallet-ui/core';
 import React, { createContext } from 'react';
 
 export interface WalletUiAccountInfo {
     account: UiWalletAccount;
     accountKeys: string[];
+    cluster: SolanaCluster;
     wallet: UiWallet | undefined;
 }
 

--- a/packages/react/src/wallet-ui-context-provider.tsx
+++ b/packages/react/src/wallet-ui-context-provider.tsx
@@ -8,7 +8,7 @@ import { useWalletUiWallets } from './use-wallet-ui-wallets';
 import { WalletUiContext, WalletUiContextProviderProps, WalletUiContextValue } from './wallet-ui-context';
 
 export function WalletUiContextProvider({ children, size = 'md' }: WalletUiContextProviderProps) {
-    const { account, accountKeys, setAccount, wallet } = useWalletUiAccount();
+    const { account, accountKeys, cluster, setAccount, wallet } = useWalletUiAccount();
     const wallets = useWalletUiWallets();
     const client = useWalletUiSolanaClient();
     const connected = Boolean(wallet && wallet?.accounts.length > 0);
@@ -32,6 +32,7 @@ export function WalletUiContextProvider({ children, size = 'md' }: WalletUiConte
         account,
         accountKeys,
         client,
+        cluster,
         connect,
         connected,
         copy,

--- a/packages/react/src/wallet-ui-context.tsx
+++ b/packages/react/src/wallet-ui-context.tsx
@@ -1,4 +1,5 @@
 import { UiWallet, UiWalletAccount } from '@wallet-standard/react';
+import { SolanaCluster } from '@wallet-ui/core';
 import { SolanaClient } from 'gill';
 import React, { ReactNode } from 'react';
 
@@ -13,6 +14,7 @@ export interface WalletUiContextValue {
     account?: UiWalletAccount;
     accountKeys: string[];
     client: SolanaClient;
+    cluster: SolanaCluster;
     connect: (wallet: UiWalletAccount) => void;
     connected: boolean;
     copy: () => void;

--- a/packages/react/src/wallet-ui.tsx
+++ b/packages/react/src/wallet-ui.tsx
@@ -31,7 +31,7 @@ export function WalletUi({ children, config: { accountStorage, clusters, cluster
                 render={({ cluster }) => {
                     return (
                         <WalletUiSolanaClientContextProvider urlOrMoniker={cluster.urlOrMoniker}>
-                            <WalletUiAccountContextProvider storage={accountStorage}>
+                            <WalletUiAccountContextProvider cluster={cluster} storage={accountStorage}>
                                 <WalletUiContextProvider {...config}>{children}</WalletUiContextProvider>
                             </WalletUiAccountContextProvider>
                         </WalletUiSolanaClientContextProvider>


### PR DESCRIPTION
When using the wallet ui in the [create-solana-dapp templates](https://github.com/solana-developers/solana-templates) I found myself repeating this all the time:

```tsx
const { account } = useWalletUi()
const { cluster } = useWalletUiCluster()
```

With this patch it can now be written like this:

```tsx
const { account, cluster } = useWalletUi()
```
