### PR TITLE
feat: add `WalletUiAccountGuard` component

### DIFF
--- a/.changeset/young-bugs-peel.md
+++ b/.changeset/young-bugs-peel.md
@@ -1,0 +1,5 @@
+---
+'@wallet-ui/react': minor
+---
+
+add `WalletUiAccountGuard` component

--- a/packages/playground-react/src/playground/account/playground-account-selected.tsx
+++ b/packages/playground-react/src/playground/account/playground-account-selected.tsx
@@ -1,4 +1,4 @@
-import { WalletUiClusterDropdown, WalletUiDropdown } from '@wallet-ui/react';
+import { WalletUiAccountGuard, WalletUiClusterDropdown, WalletUiDropdown } from '@wallet-ui/react';
 import React from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
 import { UiPanel, UiStack } from '../../ui/';
@@ -7,7 +7,6 @@ import { PlaygroundErrorBoundaryNotSupported } from '../playground-error-boundar
 import { PlaygroundSignAndSendTx } from './playground-sign-and-send-tx';
 import { PlaygroundSignInMenuButtons } from './playground-sign-in-menu-buttons';
 import { PlaygroundSignMessageBase } from './playground-sign-message-base';
-import { WalletUiAccountGuard } from './wallet-ui-account-guard';
 
 export function PlaygroundAccountSelected() {
     return (

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -19,6 +19,7 @@ export * from './use-wallet-ui-wallets';
 export * from './wallet-ui';
 export * from './wallet-ui-account-context';
 export * from './wallet-ui-account-context-provider';
+export * from './wallet-ui-account-guard';
 export * from './wallet-ui-button';
 export * from './wallet-ui-cluster-context';
 export * from './wallet-ui-cluster-context-provider';

--- a/packages/react/src/wallet-ui-account-guard.tsx
+++ b/packages/react/src/wallet-ui-account-guard.tsx
@@ -1,5 +1,8 @@
-import { useWalletUiAccount, WalletUiAccountInfo, WalletUiDropdown } from '@wallet-ui/react';
 import React from 'react';
+
+import { useWalletUiAccount } from './use-wallet-ui-account';
+import { WalletUiAccountInfo } from './wallet-ui-account-context';
+import { WalletUiDropdown } from './wallet-ui-dropdown';
 
 export interface WalletUiAccountGuardProps {
     fallback?: React.ReactNode;


### PR DESCRIPTION
This commit introduces a new component, `WalletUiAccountGuard`, which allows conditionally rendering UI based on the presence of a wallet account.

The `WalletUiAccountGuard` component takes two props:
- `render`: A function that receives the account information and returns a React node to render when an account is connected.
- `fallback`: An optional React node to render when no account is connected. This defaults to the `WalletUiDropdown` component.

Usage:

```tsx
<WalletUiAccountGuard
  render={({ account }) => (
    <div>
      <h2>Welcome, {account.publicKey.toBase58()}!</h2>
      {/* Other account-specific UI */}
    </div>
  )}
/>
```