### PR TITLE
fix(react): prevent crash in `useWalletUiSigner` when wallet is disconnected

### DIFF
--- a/.changeset/curly-camels-wash.md
+++ b/.changeset/curly-camels-wash.md
@@ -1,0 +1,5 @@
+---
+'@wallet-ui/react': major
+---
+
+prevent crash in `useWalletUiSigner` when wallet is disconnected

--- a/packages/playground-react/src/playground/account/playground-sign-and-send-tx.tsx
+++ b/packages/playground-react/src/playground/account/playground-sign-and-send-tx.tsx
@@ -1,10 +1,10 @@
 import {
     getUiWalletAccountStorageKey,
     type UiWalletAccount,
-    useWalletAccountTransactionSendingSigner,
     useWallets,
     useWalletUi,
     useWalletUiCluster,
+    useWalletUiSigner,
 } from '@wallet-ui/react';
 import {
     assertIsTransactionMessageWithSingleSendingSigner,
@@ -43,8 +43,7 @@ export function PlaygroundSignAndSendTx({ account }: { account: UiWalletAccount 
             }
         }
     }, [recipientAccountStorageKey, wallets]);
-    const transactionSendingSigner = useWalletAccountTransactionSendingSigner(account, cluster.id);
-
+    const transactionSendingSigner = useWalletUiSigner({ account });
     async function submit() {
         resetError();
         setIsSendingTransaction(true);

--- a/packages/react/src/use-wallet-ui-signer.tsx
+++ b/packages/react/src/use-wallet-ui-signer.tsx
@@ -3,8 +3,8 @@ import { UiWalletAccount } from '@wallet-standard/react';
 
 import { useWalletUi } from './use-wallet-ui';
 
-export function useWalletUiSigner() {
-    const { account, cluster } = useWalletUi();
+export function useWalletUiSigner({ account }: { account: UiWalletAccount }) {
+    const { cluster } = useWalletUi();
 
-    return useWalletAccountTransactionSendingSigner(account as UiWalletAccount, cluster.id);
+    return useWalletAccountTransactionSendingSigner(account, cluster.id);
 }


### PR DESCRIPTION
Previously, the `useWalletUiSigner` hook assumed a wallet account was always available. This caused a `TypeError` if the component using the hook rendered before a wallet was connected, crashing the application.

This commit introduces two changes to fix this:
1.  A new `WalletUiAccountGuard` component is added in #251. This component wraps parts of the UI that require a connected wallet, providing the `account` object as a render prop only when available.
2.  The `useWalletUiSigner` hook is updated to accept the `UiWalletAccount` as a parameter, making the dependency explicit.

This new pattern ensures that components requiring a signer will only render when a wallet is connected, preventing runtime errors and making the data flow more predictable.

Fixes https://github.com/solana-foundation/templates/issues/67

## Before

The `useWalletUiSigner` hook assumed a connected wallet account which was a bug.

The code below will yield an error if the wallet is not connected

```tsx
function SignerDemoBefore() {
    //  TypeError: Cannot read properties of undefined (reading 'chains')
    //      at useSignAndSendTransactions (@solana_react.js?v=9146ccaf:46:24)
    //      at useSignAndSendTransaction (@solana_react.js?v=9146ccaf:36:35)
    //      at useWalletAccountTransactionSendingSigner (@solana_react.js?v=9146ccaf:280:34)
    //      at useWalletUiSigner (use-wallet-ui-signer.tsx:9:12)
    const signer = useWalletUiSigner()
    return <div>
        My signer: {signer.address}
    </div>
}
```

## After

Wrap your Solana code in a `WalletUiAccountGuard` component.

This ensures a wallet is connected and passes it as a render prop.

This can then be used in any child components.

```tsx
function SignerDemoAfter() {
    return <WalletUiAccountGuard
        render={({ account }) => <SignerDemoAfterWithAccount account={account }/>}
    />
}

function SignerDemoAfterWithAccount({ account }: { account: UiWalletAccount }) {
    const signer = useWalletUiSigner({ account })
    return <div>
        My signer: {signer.address}
    </div>
}
```