### PR TITLE
Add missing space in homepage tagline

### DIFF
--- a/docs/src/app/(home)/page.tsx
+++ b/docs/src/app/(home)/page.tsx
@@ -23,6 +23,7 @@ export default function HomePage() {
                         className="text-fd-foreground font-semibold underline"
                         external
                     >
+                        {' '}
                         Wallet Standard
                     </Link>
                     .

--- a/docs/src/app/(home)/page.tsx
+++ b/docs/src/app/(home)/page.tsx
@@ -17,13 +17,12 @@ export default function HomePage() {
 
             <section className="mx-auto space-y-3 flex flex-col items-center gap-2 ">
                 <p className="max-w-md text-fd-muted-foreground">
-                    Wallet UI is the modern UI for the
+                    Wallet UI is the modern UI for the{' '}
                     <Link
                         href="https://github.com/wallet-standard/wallet-standard"
                         className="text-fd-foreground font-semibold underline"
                         external
                     >
-                        {' '}
                         Wallet Standard
                     </Link>
                     .


### PR DESCRIPTION
<img width="394" height="167" alt="image" src="https://github.com/user-attachments/assets/7bf292c6-5ad1-434e-b7c0-1b07cc4f9df0" />
