### PR TITLE
chore: vendor in build scripts from anza-xyz/kit

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -4,11 +4,9 @@ on:
   workflow_dispatch:
     branches:
       - main
-      - backport/**
   push:
     branches:
       - main
-      - backport/**
 
 permissions:
   contents: read

--- a/packages/build-scripts/constants.ts
+++ b/packages/build-scripts/constants.ts
@@ -1,0 +1,3 @@
+export const ORG_NAME = 'wallet-ui';
+export const REPO_NAME = 'wallet-ui';
+export const SEMVER_REGEX = /^0*(\d+)\.0*(\d+)\.0*(\d+)$/;

--- a/packages/build-scripts/current-linked-version.ts
+++ b/packages/build-scripts/current-linked-version.ts
@@ -1,0 +1,35 @@
+import { getPackages } from '@manypkg/get-packages';
+
+export async function getCurrentLinkedVersion() {
+    /**
+     * Get a list of all the packages, their paths, and their `package.json` files.
+     */
+    const { packages: allPackages } = await getPackages(import.meta.dirname);
+    const packages = allPackages.filter(p => p.relativeDir.startsWith('packages/'));
+
+    /**
+     * Compute the version that they all share. Fail unless they all share the same version.
+     */
+    let version: string | undefined;
+    for (const {
+        packageJson: { private: isPrivate, version: packageVersion },
+    } of packages) {
+        if (isPrivate) {
+            continue;
+        }
+        if (!version) {
+            version = packageVersion;
+        } else if (version !== packageVersion) {
+            throw new Error('Expected all versions to be identical');
+        }
+    }
+    if (!version) {
+        throw new Error('Found no packages');
+    }
+    const tag = `v${version}`;
+    return {
+        packages,
+        tag,
+        version,
+    };
+}

--- a/packages/build-scripts/github-api.ts
+++ b/packages/build-scripts/github-api.ts
@@ -1,0 +1,24 @@
+import { Octokit } from '@octokit/rest';
+import minimist from 'minimist';
+
+const config = minimist(process.argv.slice(2), {
+    string: 'token',
+});
+
+const GITHUB_TOKEN = config.token ?? (process.env.GH_TOKEN || process.env.GITHUB_TOKEN);
+if (typeof GITHUB_TOKEN !== 'string') {
+    console.error(
+        'The required --token argument was not provided. Please use it to supply a GitHub token with write permissions',
+    );
+    process.exit(1);
+}
+
+let api: Octokit;
+export function getGitHubApi(): Octokit {
+    if (!api) {
+        api = new Octokit({
+            auth: GITHUB_TOKEN,
+        });
+    }
+    return api;
+}

--- a/packages/build-scripts/prior-release.ts
+++ b/packages/build-scripts/prior-release.ts
@@ -1,0 +1,68 @@
+import { RestEndpointMethodTypes } from '@octokit/rest';
+import minimist from 'minimist';
+
+import { ORG_NAME, REPO_NAME, SEMVER_REGEX } from './constants.js';
+import { getGitHubApi } from './github-api.js';
+
+function cmpVersions(a: string, b: string): number {
+    const stripZeroesRegex = /(\\.0+)+$/;
+    const semverPartsA = a.replace(stripZeroesRegex, '').split('.');
+    const semverPartsB = b.replace(stripZeroesRegex, '').split('.');
+    for (let ii = 0; ii < Math.min(semverPartsA.length, semverPartsB.length); ii++) {
+        const diff = parseInt(semverPartsA[ii], 10) - parseInt(semverPartsB[ii], 10);
+        if (diff) return diff;
+    }
+    return semverPartsA.length - semverPartsB.length;
+}
+
+const config = minimist(process.argv.slice(2), {
+    boolean: 'dry-run',
+});
+
+const api = getGitHubApi();
+
+export async function getPriorRelease(version: string): Promise<{
+    makeLatest: boolean;
+    priorRelease: RestEndpointMethodTypes['repos']['listReleases']['response']['data'][number] | undefined;
+    releases: RestEndpointMethodTypes['repos']['listReleases']['response']['data'];
+}> {
+    const [_, major] = version.match(SEMVER_REGEX)!;
+
+    /**
+     * Find the release just before the current one, if any.
+     */
+    const releases = await api.paginate<RestEndpointMethodTypes['repos']['listReleases']['response']['data'][number]>(
+        api.repos.listReleases.endpoint.merge({
+            owner: ORG_NAME,
+            repo: REPO_NAME,
+        }),
+    );
+    if (!config['dry-run'] && releases.some(({ tag_name: releaseTagName }) => releaseTagName === `v${version}`)) {
+        throw new Error(`There is already a latest release on GitHub for v${version}`);
+    }
+    let priorRelease: RestEndpointMethodTypes['repos']['listReleases']['response']['data'][number] | undefined;
+    releases.forEach(release => {
+        const candidateVersion = release.tag_name.replace(/^v/, '');
+        const [_, candidateMajor] = candidateVersion.match(SEMVER_REGEX)!;
+        if (parseInt(candidateMajor, 10) > parseInt(major, 10)) {
+            return;
+        }
+        if (candidateMajor === major && cmpVersions(candidateVersion, version) > 0) {
+            // throw new Error(
+            //     `Current version (${version}) is older than version of published release of the same major (${candidateVersion})`,
+            // );
+        }
+        if (!priorRelease || cmpVersions(priorRelease.tag_name.replace(/^v/, ''), candidateVersion) <= 0) {
+            priorRelease = release;
+        }
+    });
+    const makeLatest = releases.every(release => {
+        console.log('makeLatest', release);
+        return cmpVersions('v2.0.0'.replace(/^v/, ''), version.replace(/^v/, '')) <= 0;
+    });
+    return {
+        makeLatest,
+        priorRelease,
+        releases,
+    };
+}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Vendor in build scripts from `anza-xyz/kit`, refactoring for modularity and adding shared utilities.
> 
>   - **Refactoring**:
>     - Refactor `create-github-release.ts` to use `getCurrentLinkedVersion` and `getPriorRelease` for version management.
>     - Move GitHub API initialization to `github-api.ts`.
>   - **New Files**:
>     - Add `constants.ts` for shared constants like `ORG_NAME`, `REPO_NAME`, and `SEMVER_REGEX`.
>     - Add `current-linked-version.ts` to determine the current version of linked packages.
>     - Add `prior-release.ts` to handle prior release logic.
>   - **Workflow Changes**:
>     - Remove `backport/**` branch from `.github/workflows/publish-packages.yml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=wallet-ui%2Fwallet-ui&utm_source=github&utm_medium=referral)<sup> for 281d20f13fd1d230e3eef469a77b12d35d37a1bc. You can [customize](https://app.ellipsis.dev/wallet-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->