### PR TITLE
feat(playground): add getSolanaNetworkFromGenesisHash function

### DIFF
--- a/packages/playground-react/src/lib/get-solana-network-from-genesis-hash.ts
+++ b/packages/playground-react/src/lib/get-solana-network-from-genesis-hash.ts
@@ -1,0 +1,27 @@
+/*
+ * From https://github.com/samui-build/samui-wallet and adapted for Wallet UI
+ * MIT License
+ * Copyright (c) 2023 Solana Foundation
+ */
+import { SolanaClusterId } from '@wallet-ui/react';
+
+export const GENESIS_HASH = {
+    devnet: 'EtWTRABZaYq6iMfeYKouRu166VU2xqa1wcaWoxPkrZBG',
+    mainnet: '5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc147dw2N9d',
+    testnet: '4uhcVJyU9pJkvQyS88uRDiswHXSCkY3zQawwpjk2NsNY',
+};
+/**
+ * Determine the Solana Network from its genesis hash
+ */
+export function getSolanaNetworkFromGenesisHash(hash: string): SolanaClusterId {
+    switch (hash) {
+        case GENESIS_HASH.devnet:
+            return 'solana:devnet';
+        case GENESIS_HASH.mainnet:
+            return 'solana:mainnet';
+        case GENESIS_HASH.testnet:
+            return 'solana:testnet';
+        default:
+            return 'solana:localnet';
+    }
+}

--- a/packages/playground-react/src/playground/client/playground-client.tsx
+++ b/packages/playground-react/src/playground/client/playground-client.tsx
@@ -1,6 +1,6 @@
 import { useWalletUiGill } from '@wallet-ui/react-gill';
-import { getMonikerFromGenesisHash } from 'gill';
 import React from 'react';
+import { getSolanaNetworkFromGenesisHash } from '../../lib/get-solana-network-from-genesis-hash';
 import { UiCard } from '../../ui/';
 import { PlaygroundRunCommand } from './playground-run-command';
 
@@ -20,7 +20,7 @@ export function PlaygroundClient() {
                 .send()
                 .then(genesisHash => ({
                     genesisHash,
-                    cluster: getMonikerFromGenesisHash(genesisHash),
+                    cluster: getSolanaNetworkFromGenesisHash(genesisHash),
                 })),
         );
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `getSolanaNetworkFromGenesisHash` function to map Solana genesis hashes to network identifiers and update client usage.
> 
>   - **Functionality**:
>     - Adds `getSolanaNetworkFromGenesisHash` in `get-solana-network-from-genesis-hash.ts` to map genesis hashes to Solana network identifiers.
>     - Handles `devnet`, `mainnet`, `testnet`, and defaults to `localnet`.
>   - **Integration**:
>     - Replaces `getMonikerFromGenesisHash` with `getSolanaNetworkFromGenesisHash` in `playground-client.tsx` to determine the cluster from genesis hash.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=wallet-ui%2Fwallet-ui&utm_source=github&utm_medium=referral)<sup> for 3eeb96ddf9357d6f93ab8017ca065e7a23c5e15a. You can [customize](https://app.ellipsis.dev/wallet-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->