### PR TITLE
feat(core): add urlWs to SolanaCluster and update cluster factories

### DIFF
--- a/.changeset/every-waves-poke.md
+++ b/.changeset/every-waves-poke.md
@@ -1,0 +1,24 @@
+---
+'@wallet-ui/core': major
+---
+
+Breaking changes to default cluster creation functions
+
+### Breaking Change
+
+The behavior of the default cluster creation functions (`createSolanaDevnet`, `createSolanaMainnet`, etc.) has been changed. They now return full RPC URLs instead of symbolic names.
+
+**What changed (Breaking):**
+- Calling a creation function like `createSolanaDevnet()` with no arguments will now return a cluster with a full URL, e.g., `url: 'https://api.devnet.solana.com'`. Previously, it returned a symbolic name, e.g., `url: 'devnet'`. This is a breaking change for anyone who was relying on the symbolic names.
+
+**What changed (Non-Breaking):**
+- To support more flexible RPC configurations, the `SolanaCluster` interface now has an optional `urlWs` property for a dedicated WebSocket endpoint.
+- The creation functions have been updated to accept a `urlWs` property.
+- `createSolanaLocalnet` will now automatically infer a WebSocket URL (e.g., `ws://localhost:8900`) if a standard HTTP URL is provided (e.g., `http://localhost:8899`).
+
+**Why this change was made:**
+To improve the developer experience with better defaults and to provide more flexibility by allowing separate RPC and WebSocket URLs.
+
+**How to update your code:**
+- If your code checks for symbolic cluster names (e.g., `if (cluster.url === 'devnet')`), you must update it to handle full RPC URLs.
+- If you have a custom WebSocket endpoint, you can now provide it via the `urlWs` property when creating a `SolanaCluster`.

--- a/packages/core/src/__tests__/create-solana-cluster-test.ts
+++ b/packages/core/src/__tests__/create-solana-cluster-test.ts
@@ -9,7 +9,7 @@ describe('createSolanaCluster', () => {
             {
               "id": "solana:devnet",
               "label": "Devnet",
-              "url": "devnet",
+              "url": "https://api.devnet.solana.com",
             }
         `);
     });
@@ -21,7 +21,7 @@ describe('createSolanaCluster', () => {
             {
               "id": "solana:devnet",
               "label": "Devnet",
-              "url": "devnet",
+              "url": "https://api.devnet.solana.com",
             }
         `);
     });
@@ -34,7 +34,7 @@ describe('createSolanaCluster', () => {
             {
               "id": "solana:localnet",
               "label": "Localnet",
-              "url": "localnet",
+              "url": "http://localhost:8899",
             }
         `);
     });
@@ -47,7 +47,7 @@ describe('createSolanaCluster', () => {
             {
               "id": "solana:testnet",
               "label": "Testnet",
-              "url": "testnet",
+              "url": "https://api.testnet.solana.com",
             }
         `);
     });
@@ -75,6 +75,7 @@ describe('createSolanaCluster', () => {
               "id": "solana:localnet",
               "label": "Custom Local",
               "url": "http://host.docker.internal:8899",
+              "urlWs": "ws://host.docker.internal:8900",
             }
         `);
     });

--- a/packages/core/src/__typetests__/create-solana-cluster-typetets.ts
+++ b/packages/core/src/__typetests__/create-solana-cluster-typetets.ts
@@ -38,7 +38,10 @@ import { SolanaCluster } from '../types/solana-cluster';
         result satisfies SolanaCluster;
     }
     {
-        const result: SolanaCluster = createSolanaTestnet({ label: 'Custom Testnet' });
+        const result: SolanaCluster = createSolanaTestnet({
+            label: 'Custom Testnet',
+            url: 'https://api.testnet.solana.com',
+        });
         result satisfies SolanaCluster;
     }
     {
@@ -46,7 +49,7 @@ import { SolanaCluster } from '../types/solana-cluster';
         result satisfies SolanaCluster;
     }
     {
-        const result: SolanaCluster = createSolanaMainnet();
+        const result: SolanaCluster = createSolanaMainnet('https://api.mainnet-beta.solana.com');
         result satisfies SolanaCluster;
     }
     {

--- a/packages/core/src/clusters.ts
+++ b/packages/core/src/clusters.ts
@@ -1,4 +1,7 @@
-import type {
+import { devnet, mainnet, testnet } from '@solana/kit';
+
+import {
+    localnet,
     SolanaCluster,
     SolanaDevnetUrl,
     SolanaLocalnetUrl,
@@ -6,47 +9,58 @@ import type {
     SolanaTestnetUrl,
 } from './types/solana-cluster';
 
-export type CreateSolanaProps = Partial<Pick<SolanaCluster, 'label' | 'url'>> | string;
+export type CreateSolanaProps = string | (Partial<Pick<SolanaCluster, 'label' | 'url' | 'urlWs'>> & { url: string });
 
 function createSolanaCluster<T extends SolanaDevnetUrl | SolanaLocalnetUrl | SolanaMainnetUrl | SolanaTestnetUrl>(
     props: CreateSolanaProps,
-    { id, label, url }: SolanaCluster,
-): Pick<SolanaCluster, 'id' | 'label' | 'url'> {
+    { id, label, url: defaultUrl, urlWs: defaultUrlWs }: Pick<SolanaCluster, 'id' | 'label' | 'url' | 'urlWs'>,
+): SolanaCluster {
     if (typeof props === 'string') {
         return { id, label, url: props as T };
     }
 
-    return { id, label: props.label ?? label, url: props.url ?? url };
+    return {
+        id,
+        label: props.label ?? label,
+        url: props.url ?? defaultUrl,
+        urlWs: props.urlWs ?? defaultUrlWs,
+    };
 }
 
-export function createSolanaDevnet(props: CreateSolanaProps = {}): SolanaCluster {
+export function createSolanaDevnet(props: CreateSolanaProps = 'https://api.devnet.solana.com'): SolanaCluster {
     return createSolanaCluster<SolanaDevnetUrl>(props, {
         id: 'solana:devnet',
         label: 'Devnet',
-        url: 'devnet' as SolanaDevnetUrl,
+        url: devnet(typeof props === 'string' ? props : props.url),
     });
 }
 
-export function createSolanaLocalnet(props: CreateSolanaProps = {}): SolanaCluster {
+export function createSolanaLocalnet(props: CreateSolanaProps = 'http://localhost:8899'): SolanaCluster {
+    const url = typeof props === 'string' ? props : props.url;
+    const urlWs = typeof props !== 'string' ? (props.urlWs ?? getLocalUrlWs(url)) : undefined;
     return createSolanaCluster(props, {
         id: 'solana:localnet',
         label: 'Localnet',
-        url: 'localnet' as SolanaLocalnetUrl,
+        url: localnet(url),
+        urlWs,
     });
 }
 
-export function createSolanaMainnet(props: CreateSolanaProps = {}): SolanaCluster {
+function getLocalUrlWs(url: string) {
+    return url.endsWith(':8899') ? url.replace(':8899', ':8900').replace('http', 'ws') : undefined;
+}
+export function createSolanaMainnet(props: CreateSolanaProps): SolanaCluster {
     return createSolanaCluster(props, {
         id: 'solana:mainnet',
         label: 'Mainnet',
-        url: 'mainnet' as SolanaMainnetUrl,
+        url: mainnet(typeof props === 'string' ? props : props.url),
     });
 }
 
-export function createSolanaTestnet(props: CreateSolanaProps = {}): SolanaCluster {
+export function createSolanaTestnet(props: CreateSolanaProps = 'https://api.testnet.solana.com'): SolanaCluster {
     return createSolanaCluster(props, {
         id: 'solana:testnet',
         label: 'Testnet',
-        url: 'testnet' as SolanaTestnetUrl,
+        url: testnet(typeof props === 'string' ? props : props.url),
     });
 }

--- a/packages/core/src/types/solana-cluster.ts
+++ b/packages/core/src/types/solana-cluster.ts
@@ -10,8 +10,13 @@ export type { SolanaDevnetUrl, SolanaMainnetUrl, SolanaTestnetUrl };
 
 export type SolanaLocalnetUrl = string & { '~cluster': 'localnet' };
 
+export function localnet(url: string) {
+    return url as SolanaLocalnetUrl;
+}
+
 export interface SolanaCluster {
     id: SolanaClusterId;
     label: string;
     url: SolanaDevnetUrl | SolanaLocalnetUrl | SolanaMainnetUrl | SolanaTestnetUrl | string;
+    urlWs?: string;
 }


### PR DESCRIPTION
Breaking changes to default cluster creation functions

### Breaking Change

The behavior of the default cluster creation functions (`createSolanaDevnet`, `createSolanaMainnet`, etc.) has been changed. They now return full RPC URLs instead of symbolic names.

**What changed (Breaking):**
- Calling a creation function like `createSolanaDevnet()` with no arguments will now return a cluster with a full URL, e.g., `url: 'https://api.devnet.solana.com'`. Previously, it returned a symbolic name, e.g., `url: 'devnet'`. This is a breaking change for anyone who was relying on the symbolic names.

**What changed (Non-Breaking):**
- To support more flexible RPC configurations, the `SolanaCluster` interface now has an optional `urlWs` property for a dedicated WebSocket endpoint.
- The creation functions have been updated to accept a `urlWs` property.
- `createSolanaLocalnet` will now automatically infer a WebSocket URL (e.g., `ws://localhost:8900`) if a standard HTTP URL is provided (e.g., `http://localhost:8899`).

**Why this change was made:**
To improve the developer experience with better defaults and to provide more flexibility by allowing separate RPC and WebSocket URLs.

**How to update your code:**
- If your code checks for symbolic cluster names (e.g., `if (cluster.url === 'devnet')`), you must update it to handle full RPC URLs.
- If you have a custom WebSocket endpoint, you can now provide it via the `urlWs` property when creating a `SolanaCluster`.

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Breaking changes to `SolanaCluster` interface: `url` deprecated, `http` required, added `urlWs` for WebSocket, updated cluster creation functions.
> 
>   - **Breaking Changes**:
>     - `SolanaCluster` interface: `url` property deprecated, `http` property required.
>     - `createSolanaDevnet`, `createSolanaMainnet`, etc., now return full URLs instead of symbolic names.
>   - **New Features**:
>     - `SolanaCluster` interface: added optional `urlWs` for WebSocket endpoints.
>     - `createSolanaLocalnet` infers WebSocket URL from HTTP URL.
>   - **Tests**:
>     - Updated `create-solana-cluster-test.ts` to reflect full URL changes and `urlWs` property.
>     - Updated `create-solana-cluster-typetets.ts` for type checks with new properties.
>   - **Functions**:
>     - `createSolanaCluster` updated to handle `urlWs` and full URLs.
>     - `getLocalUrlWs` added to infer WebSocket URL.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=wallet-ui%2Fwallet-ui&utm_source=github&utm_medium=referral)<sup> for 821e4a3829c77ed71928c373554bb5d4daa77dea. You can [customize](https://app.ellipsis.dev/wallet-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->