### PR TITLE
refactor(react-native-web3js): clean up and isolate usage of authorization storage

### DIFF
--- a/.changeset/tender-cameras-agree.md
+++ b/.changeset/tender-cameras-agree.md
@@ -1,0 +1,5 @@
+---
+'@wallet-ui/react-native-web3js': patch
+---
+
+clean up and isolate usage of authorization storage

--- a/packages/react-native-web3js/src/use-authorization-storage.ts
+++ b/packages/react-native-web3js/src/use-authorization-storage.ts
@@ -1,0 +1,33 @@
+import { useQueryClient } from '@tanstack/react-query';
+
+import { Account, WalletAuthorization } from './use-authorization';
+import { useFetchAuthorization } from './use-fetch-authorization';
+import { usePersistAuthorization } from './use-persist-authorization';
+
+export function useAuthorizationStorage() {
+    const queryKey = ['wallet-authorization'];
+    const storageKey = 'authorization-cache';
+    const queryClient = useQueryClient();
+    const fetchQuery = useFetchAuthorization({ queryKey, storageKey });
+    const persistMutation = usePersistAuthorization({ queryKey, storageKey });
+
+    async function persist(next: WalletAuthorization | null, invalidate = false) {
+        await persistMutation.mutateAsync(next);
+        if (invalidate) {
+            await queryClient.invalidateQueries({ queryKey });
+        }
+    }
+
+    const accounts = fetchQuery.data?.accounts ?? null;
+    const authToken: string | undefined = fetchQuery.data?.authToken ?? undefined;
+    const isLoading = fetchQuery.isLoading;
+    const selectedAccount: Account | undefined = fetchQuery.data?.selectedAccount ?? undefined;
+
+    return {
+        accounts,
+        authToken,
+        isLoading,
+        persist,
+        selectedAccount,
+    } as const;
+}

--- a/packages/react-native-web3js/src/use-fetch-authorization.ts
+++ b/packages/react-native-web3js/src/use-fetch-authorization.ts
@@ -3,7 +3,6 @@ import { PublicKey, PublicKeyInitData } from '@solana/web3.js';
 import { useQuery } from '@tanstack/react-query';
 
 import { WalletAuthorization } from './use-authorization';
-import { useQueryConfig } from './use-query-config';
 
 function cacheReviver(key: string, value: unknown) {
     if (key === 'publicKey') {
@@ -13,8 +12,7 @@ function cacheReviver(key: string, value: unknown) {
     }
 }
 
-export function useFetchAuthorization() {
-    const { queryKey, storageKey } = useQueryConfig();
+export function useFetchAuthorization({ queryKey, storageKey }: { queryKey: string[]; storageKey: string }) {
     return useQuery({
         queryFn: async (): Promise<WalletAuthorization | null> => {
             const cacheFetchResult = await AsyncStorage.getItem(storageKey);

--- a/packages/react-native-web3js/src/use-invalidate-authorizations.ts
+++ b/packages/react-native-web3js/src/use-invalidate-authorizations.ts
@@ -1,7 +1,0 @@
-import { useQueryConfig } from './use-query-config';
-
-export function useInvalidateAuthorizations() {
-    const { queryClient, queryKey } = useQueryConfig();
-
-    return () => queryClient.invalidateQueries({ queryKey });
-}

--- a/packages/react-native-web3js/src/use-persist-authorization.ts
+++ b/packages/react-native-web3js/src/use-persist-authorization.ts
@@ -1,11 +1,10 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 import { WalletAuthorization } from './use-authorization';
-import { useQueryConfig } from './use-query-config';
 
-export function usePersistAuthorization() {
-    const { queryClient, queryKey, storageKey } = useQueryConfig();
+export function usePersistAuthorization({ queryKey, storageKey }: { queryKey: string[]; storageKey: string }) {
+    const queryClient = useQueryClient();
     return useMutation({
         mutationFn: async (auth: WalletAuthorization | null): Promise<void> => {
             await AsyncStorage.setItem(storageKey, JSON.stringify(auth));

--- a/packages/react-native-web3js/src/use-query-config.ts
+++ b/packages/react-native-web3js/src/use-query-config.ts
@@ -1,9 +1,0 @@
-import { useQueryClient } from '@tanstack/react-query';
-
-export function useQueryConfig() {
-    const storageKey = 'authorization-cache';
-    const queryClient = useQueryClient();
-    const queryKey = ['wallet-authorization'];
-
-    return { queryClient, queryKey, storageKey };
-}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Refactor `react-native-web3js` to centralize authorization storage logic with `useAuthorizationStorage`.
> 
>   - **New Hook**:
>     - Introduces `useAuthorizationStorage` in `use-authorization-storage.ts` to centralize authorization storage logic.
>     - Manages `accounts`, `authToken`, `isLoading`, `persist`, and `selectedAccount`.
>   - **Refactoring**:
>     - Replaces `useFetchAuthorization`, `usePersistAuthorization`, and `useInvalidateAuthorizations` in `use-authorization.ts` with `useAuthorizationStorage`.
>     - Removes `useQueryConfig` and `useInvalidateAuthorizations`.
>   - **Function Changes**:
>     - Updates `useFetchAuthorization` and `usePersistAuthorization` to accept `queryKey` and `storageKey` as parameters.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=wallet-ui%2Fwallet-ui&utm_source=github&utm_medium=referral)<sup> for 566d105ff29c803b79f8deb56d74a4b84b9f4459. You can [customize](https://app.ellipsis.dev/wallet-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->