### PR TITLE
refactor(react-native-web3js): deprecate `Account.publicKey` in favor of `Account.address`

### DIFF
--- a/.changeset/refactor-account-address-field.md
+++ b/.changeset/refactor-account-address-field.md
@@ -1,0 +1,5 @@
+---
+"@wallet-ui/react-native-web3js": major
+---
+
+Refactor: deprecate `Account.publicKey` in favor of `Account.address` in `react-native-web3js` package.

--- a/examples/expo-web3js/features/account/account-feature-get-balance.tsx
+++ b/examples/expo-web3js/features/account/account-feature-get-balance.tsx
@@ -2,8 +2,8 @@ import { Text } from 'react-native';
 import { LAMPORTS_PER_SOL, PublicKey } from '@solana/web3.js';
 import { useAccountGetBalance } from '@/features/account/use-account-get-balance';
 
-export function AccountFeatureGetBalance({ publicKey }: { publicKey: PublicKey }) {
-    const { data, isLoading } = useAccountGetBalance({ publicKey });
+export function AccountFeatureGetBalance({ address }: { address: PublicKey }) {
+    const { data, isLoading } = useAccountGetBalance({ address });
 
     return <Text>Balance: {isLoading ? '...' : `${(data ?? 0) / LAMPORTS_PER_SOL} SOL`}</Text>;
 }

--- a/examples/expo-web3js/features/account/account-feature-index.tsx
+++ b/examples/expo-web3js/features/account/account-feature-index.tsx
@@ -19,11 +19,11 @@ export function AccountFeatureIndex() {
                 <View style={appStyles.stack}>
                     <View style={appStyles.card}>
                         <Text>Connected to {account.label}</Text>
-                        <AccountFeatureGetBalance publicKey={account.publicKey} />
+                        <AccountFeatureGetBalance address={account.address} />
                     </View>
                     <AccountFeatureSignIn account={account} />
-                    <AccountFeatureSignMessage publicKey={account.publicKey} />
-                    <AccountFeatureSignTransaction publicKey={account.publicKey} />
+                    <AccountFeatureSignMessage address={account.address} />
+                    <AccountFeatureSignTransaction address={account.address} />
                     <AccountFeatureDisconnect />
                 </View>
             ) : (

--- a/examples/expo-web3js/features/account/account-feature-sign-in.tsx
+++ b/examples/expo-web3js/features/account/account-feature-sign-in.tsx
@@ -7,7 +7,7 @@ export function AccountFeatureSignIn({ account }: { account?: Account }) {
     const { signIn } = useMobileWallet();
     async function submit() {
         try {
-            await signIn({ address: account?.publicKey?.toString(), uri: AppConfig.identity.uri });
+            await signIn({ address: account?.address?.toString(), uri: AppConfig.identity.uri });
             console.log('Signed in!');
         } catch (e) {
             console.log(`Error signing in: ${e}`);

--- a/examples/expo-web3js/features/account/account-feature-sign-message.tsx
+++ b/examples/expo-web3js/features/account/account-feature-sign-message.tsx
@@ -3,11 +3,11 @@ import { Button, View } from 'react-native';
 import { appStyles } from '@/constants/app-styles';
 import { toUint8Array, useMobileWallet } from '@wallet-ui/react-native-web3js';
 
-export function AccountFeatureSignMessage({ publicKey }: { publicKey: PublicKey }) {
+export function AccountFeatureSignMessage({ address }: { address: PublicKey }) {
     const { signMessage } = useMobileWallet();
     async function submit() {
         try {
-            await signMessage(toUint8Array(`Signing a message with ${publicKey.toString()}`));
+            await signMessage(toUint8Array(`Signing a message with ${address.toString()}`));
             console.log('Message signed!');
         } catch (e) {
             console.log(`Error signing message: ${e}`);

--- a/examples/expo-web3js/features/account/account-feature-sign-transaction.tsx
+++ b/examples/expo-web3js/features/account/account-feature-sign-transaction.tsx
@@ -4,7 +4,7 @@ import { appStyles } from '@/constants/app-styles';
 import { createMemoInstruction } from '@solana/spl-memo';
 import { useMobileWallet } from '@wallet-ui/react-native-web3js';
 
-export function AccountFeatureSignTransaction({ publicKey }: { publicKey: PublicKey }) {
+export function AccountFeatureSignTransaction({ address }: { address: PublicKey }) {
     const { connection, signAndSendTransaction } = useMobileWallet();
 
     async function submit() {
@@ -15,7 +15,7 @@ export function AccountFeatureSignTransaction({ publicKey }: { publicKey: Public
             } = await connection.getLatestBlockhashAndContext();
 
             const message = new TransactionMessage({
-                payerKey: publicKey,
+                payerKey: address,
                 recentBlockhash: latestBlockhash.blockhash,
                 instructions: [
                     // You can add more instructions here

--- a/examples/expo-web3js/features/account/use-account-get-balance.tsx
+++ b/examples/expo-web3js/features/account/use-account-get-balance.tsx
@@ -2,10 +2,10 @@ import { useQuery } from '@tanstack/react-query';
 import { PublicKey } from '@solana/web3.js';
 import { useMobileWallet } from '@wallet-ui/react-native-web3js';
 
-export function useAccountGetBalance({ publicKey }: { publicKey: PublicKey }) {
+export function useAccountGetBalance({ address }: { address: PublicKey }) {
     const { chain, connection } = useMobileWallet();
     return useQuery({
-        queryKey: ['get-balance', chain, publicKey.toString()],
-        queryFn: () => connection.getBalance(publicKey),
+        queryKey: ['get-balance', chain, address.toString()],
+        queryFn: () => connection.getBalance(address),
     });
 }

--- a/packages/react-native-web3js/src/get-account-from-authorized-account.ts
+++ b/packages/react-native-web3js/src/get-account-from-authorized-account.ts
@@ -10,12 +10,13 @@ function ellipsify(str = '', len = 4, delimiter = '..') {
 }
 
 export function getAccountFromAuthorizedAccount(account: AuthorizedAccount): Account {
-    const publicKey = getPublicKeyFromAddress(account.address);
+    const address = getPublicKeyFromAddress(account.address);
 
     return {
-        address: account.address,
+        address,
+        addressBase64: account.address,
         icon: account.icon,
-        label: account.label ?? ellipsify(publicKey.toString(), 8),
-        publicKey,
+        label: account.label ?? ellipsify(address.toString(), 8),
+        publicKey: address,
     };
 }

--- a/packages/react-native-web3js/src/get-authorization-from-authorization-result.ts
+++ b/packages/react-native-web3js/src/get-authorization-from-authorization-result.ts
@@ -12,7 +12,7 @@ export function getAuthorizationFromAuthorizationResult(
         // We have yet to select an account.
         previouslySelectedAccount == null ||
         // The previously selected account is no longer in the set of authorized addresses.
-        !authorizationResult.accounts.some(({ address }) => address === previouslySelectedAccount.address)
+        !authorizationResult.accounts.some(({ address }) => address === previouslySelectedAccount.addressBase64)
     ) {
         const firstAccount = authorizationResult.accounts[0];
         selectedAccount = getAccountFromAuthorizedAccount(firstAccount);

--- a/packages/react-native-web3js/src/use-authorization.ts
+++ b/packages/react-native-web3js/src/use-authorization.ts
@@ -20,9 +20,13 @@ import { getAuthorizationFromAuthorizationResult } from './get-authorization-fro
 import { useAuthorizationStore } from './use-authorization-store';
 
 export type Account = Readonly<{
-    address: Base64EncodedAddress;
+    address: PublicKey;
+    addressBase64: Base64EncodedAddress;
     icon?: WalletIcon;
     label?: string;
+    /**
+     * @deprecated Use `address` instead.
+     */
     publicKey: PublicKey;
 }>;
 

--- a/packages/react-native-web3js/src/use-mobile-wallet.ts
+++ b/packages/react-native-web3js/src/use-mobile-wallet.ts
@@ -58,7 +58,7 @@ export function useMobileWallet() {
             await transact(async wallet => {
                 const authResult = await authorizeSession(wallet);
                 const signedMessages = await wallet.signMessages({
-                    addresses: [authResult.address],
+                    addresses: [authResult.addressBase64],
                     payloads: [message],
                 });
                 return signedMessages[0];


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Refactor `react-native-web3js` to deprecate `Account.publicKey` in favor of `Account.address`, updating related functions and components.
> 
>   - **Deprecation**:
>     - Deprecate `Account.publicKey` in favor of `Account.address` in `react-native-web3js`.
>   - **Function Updates**:
>     - Update `AccountFeatureGetBalance`, `AccountFeatureSignMessage`, `AccountFeatureSignTransaction` to use `address` instead of `publicKey`.
>     - Modify `useAccountGetBalance` to accept `address`.
>   - **Internal Changes**:
>     - In `get-account-from-authorized-account.ts`, replace `publicKey` with `address` and add `addressBase64`.
>     - Update `get-authorization-from-authorization-result.ts` to use `addressBase64` for comparison.
>     - In `use-authorization.ts`, add `addressBase64` to `Account` type and mark `publicKey` as deprecated.
>     - Modify `use-mobile-wallet.ts` to use `addressBase64` in `signMessage`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=wallet-ui%2Fwallet-ui&utm_source=github&utm_medium=referral)<sup> for b102991a29400b5a00b4efdbba39fc02f84a0f15. You can [customize](https://app.ellipsis.dev/wallet-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->