### PR TITLE
fix(react-native-web3js): ensure to initialize a single store

### DIFF
--- a/.changeset/fix-react-native-web3js-store.md
+++ b/.changeset/fix-react-native-web3js-store.md
@@ -1,0 +1,5 @@
+---
+"@wallet-ui/react-native-web3js": patch
+---
+
+fix(react-native-web3js): ensure to initialize a single store

--- a/packages/react-native-web3js/src/mobile-wallet-provider.tsx
+++ b/packages/react-native-web3js/src/mobile-wallet-provider.tsx
@@ -1,8 +1,10 @@
 import { Commitment, Connection, ConnectionConfig } from '@solana/web3.js';
 import { AppIdentity, Chain } from '@solana-mobile/mobile-wallet-adapter-protocol';
-import React, { createContext, type ReactNode, useMemo } from 'react';
+import React, { createContext, type ReactNode, useEffect, useMemo, useRef } from 'react';
 
-import { WalletAuthorizationCache, WalletAuthorizationProps } from './use-authorization';
+import { createAsyncStorageCache } from './async-storage-cache';
+import { AuthorizationStore, createAuthorizationStore } from './authorization-store';
+import { WalletAuthorization, WalletAuthorizationCache, WalletAuthorizationProps } from './use-authorization';
 
 export interface MobileWalletProviderProps {
     cache?: WalletAuthorizationCache;
@@ -14,11 +16,12 @@ export interface MobileWalletProviderProps {
 }
 export interface MobileWalletProviderState extends WalletAuthorizationProps {
     connection: Connection;
+    store: AuthorizationStore;
 }
 
 export const MobileWalletProviderContext = createContext<MobileWalletProviderState>({} as MobileWalletProviderState);
 export function MobileWalletProvider({
-    cache,
+    cache: userCache,
     children,
     chain,
     commitmentOrConfig = { commitment: 'confirmed' },
@@ -26,6 +29,17 @@ export function MobileWalletProvider({
     identity,
 }: MobileWalletProviderProps) {
     const connection = useMemo(() => new Connection(endpoint, commitmentOrConfig), [commitmentOrConfig, endpoint]);
+    const cache = useMemo(() => userCache ?? createAsyncStorageCache<WalletAuthorization>(), [userCache]);
+
+    const storeRef = useRef<AuthorizationStore | null>(null);
+    if (!storeRef.current) {
+        storeRef.current = createAuthorizationStore({ cache });
+    }
+    const store = storeRef.current;
+
+    useEffect(() => {
+        store.fetch().catch(console.error);
+    }, [store]);
 
     return (
         <MobileWalletProviderContext.Provider
@@ -35,8 +49,9 @@ export function MobileWalletProvider({
                     chain,
                     connection,
                     identity,
+                    store,
                 }),
-                [cache, chain, connection, identity],
+                [cache, chain, connection, identity, store],
             )}
         >
             {children}

--- a/packages/react-native-web3js/src/use-authorization-store.ts
+++ b/packages/react-native-web3js/src/use-authorization-store.ts
@@ -1,19 +1,9 @@
 import { useStore } from '@nanostores/react';
-import { useMemo, useRef } from 'react';
+import { useMemo } from 'react';
 
-import { AuthorizationStore, createAuthorizationStore } from './authorization-store';
-import { WalletAuthorizationCache } from './use-authorization';
+import { AuthorizationStore } from './authorization-store';
 
-export function useAuthorizationStore({ cache }: { cache: WalletAuthorizationCache }) {
-    const storeRef = useRef<AuthorizationStore | null>(null);
-
-    if (!storeRef.current) {
-        storeRef.current = createAuthorizationStore({ cache });
-        storeRef.current.fetch().catch(console.error);
-    }
-
-    const store = storeRef.current;
-
+export function useAuthorizationStore({ store }: { store: AuthorizationStore }) {
     const accounts = useStore(store.$accounts);
     const authToken = useStore(store.$authToken);
     const selectedAccount = useStore(store.$selectedAccount);

--- a/packages/react-native-web3js/src/use-authorization.ts
+++ b/packages/react-native-web3js/src/use-authorization.ts
@@ -14,7 +14,7 @@ import {
 import { WalletIcon } from '@wallet-standard/core';
 import { useCallback, useMemo } from 'react';
 
-import { createAsyncStorageCache } from './async-storage-cache';
+import { AuthorizationStore } from './authorization-store';
 import { Cache } from './cache';
 import { getAuthorizationFromAuthorizationResult } from './get-authorization-from-authorization-result';
 import { useAuthorizationStore } from './use-authorization-store';
@@ -36,12 +36,11 @@ export type WalletAuthorizationProps = Readonly<{
     cache?: WalletAuthorizationCache;
     chain: Chain;
     identity: AppIdentity;
+    store: AuthorizationStore;
 }>;
-export function useAuthorization({ cache, chain, identity }: WalletAuthorizationProps) {
-    const memoizedCache = useMemo(() => cache ?? createAsyncStorageCache<WalletAuthorization>(), [cache]);
-
+export function useAuthorization({ chain, identity, store }: WalletAuthorizationProps) {
     const { accounts, authToken, persist, selectedAccount } = useAuthorizationStore({
-        cache: memoizedCache,
+        store,
     });
 
     const handleAuthorizationResult = useCallback(

--- a/packages/react-native-web3js/src/use-mobile-wallet.ts
+++ b/packages/react-native-web3js/src/use-mobile-wallet.ts
@@ -8,8 +8,14 @@ import { Account, useAuthorization } from './use-authorization';
 
 export function useMobileWallet() {
     const ctx = useContext(MobileWalletProviderContext);
-    const { authorizeSessionWithSignIn, authorizeSession, deauthorizeSessions, selectedAccount, ...authorization } =
-        useAuthorization(ctx);
+    const {
+        authorizeSessionWithSignIn,
+        authorizeSession,
+        deauthorizeSessions,
+        selectedAccount,
+        accounts,
+        deauthorizeSession,
+    } = useAuthorization(ctx);
 
     const connect = useCallback(
         async (): Promise<Account> => await transact(async wallet => await authorizeSession(wallet)),
@@ -63,20 +69,22 @@ export function useMobileWallet() {
     return useMemo(
         () => ({
             ...ctx,
-            ...authorization,
             account: selectedAccount,
+            accounts,
             connect,
             connectAnd,
+            deauthorizeSession,
             disconnect,
             signAndSendTransaction,
             signIn,
             signMessage,
         }),
         [
-            authorization,
+            accounts,
             connect,
             connectAnd,
             ctx,
+            deauthorizeSession,
             disconnect,
             selectedAccount,
             signAndSendTransaction,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Refactor `react-native-web3js` to ensure single `AuthorizationStore` initialization and update related hooks and components.
> 
>   - **Behavior**:
>     - Ensure single `AuthorizationStore` initialization in `MobileWalletProvider` by using `useRef`.
>     - Fetch store data on mount using `useEffect` in `mobile-wallet-provider.tsx`.
>   - **Hooks**:
>     - `useAuthorizationStore` now takes `store` directly instead of creating it.
>     - `useAuthorization` updated to use `store` directly, removing cache creation.
>     - `useMobileWallet` updated to use `accounts` and `deauthorizeSession` from `useAuthorization`.
>   - **Misc**:
>     - Add `store` to `MobileWalletProviderState` and `WalletAuthorizationProps`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=wallet-ui%2Fwallet-ui&utm_source=github&utm_medium=referral)<sup> for 7c2108e9ac17d59dfaa19b561a1bc65d101a32ac. You can [customize](https://app.ellipsis.dev/wallet-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->