### PR TITLE
feat(react-native-kit): add sendTransaction helper to useMobileWallet

### DIFF
--- a/.changeset/add-send-transaction-hook.md
+++ b/.changeset/add-send-transaction-hook.md
@@ -1,0 +1,5 @@
+---
+"@wallet-ui/react-native-kit": minor
+---
+
+feat: add `sendTransaction` to `useMobileWallet`

--- a/examples/expo-kit/features/account/account-feature-sign-transaction.tsx
+++ b/examples/expo-kit/features/account/account-feature-sign-transaction.tsx
@@ -2,47 +2,20 @@ import { Button, View } from 'react-native';
 import { appStyles } from '@/constants/app-styles';
 import { getAddMemoInstruction } from '@solana-program/memo';
 import { useMobileWallet } from '@wallet-ui/react-native-kit';
-import {
-    Address,
-    appendTransactionMessageInstructions,
-    createTransactionMessage,
-    getBase58Decoder,
-    Instruction,
-    pipe,
-    setTransactionMessageFeePayerSigner,
-    setTransactionMessageLifetimeUsingBlockhash,
-    signAndSendTransactionMessageWithSigners,
-} from '@solana/kit';
+import { Address, Instruction } from '@solana/kit';
 
 export function AccountFeatureSignTransaction({ address }: { address: Address }) {
-    const { client, getTransactionSigner } = useMobileWallet();
+    const { sendTransaction } = useMobileWallet();
 
     async function submit() {
         console.log('submit');
         try {
-            const {
-                context: { slot: minContextSlot },
-                value: latestBlockhash,
-            } = await client.rpc.getLatestBlockhash().send();
-
             const instructions: Instruction[] = [
                 // You can add more instructions here
-                getAddMemoInstruction({ memo: 'Hello from Mobile Wallet Adapter' }),
+                getAddMemoInstruction({ memo: `gm from Mobile Wallet Adapter - ${address}` }),
             ];
 
-            // Create an MWA transaction signer
-            const signer = getTransactionSigner(address, minContextSlot);
-
-            // const transaction = new VersionedTransaction(message);
-            const transaction = pipe(
-                createTransactionMessage({ version: 0 }),
-                tx => appendTransactionMessageInstructions(instructions, tx),
-                tx => setTransactionMessageFeePayerSigner(signer, tx),
-                tx => setTransactionMessageLifetimeUsingBlockhash(latestBlockhash, tx),
-            );
-
-            const signatureBytes = await signAndSendTransactionMessageWithSigners(transaction);
-            const signature = getBase58Decoder().decode(signatureBytes);
+            const signature = await sendTransaction(instructions);
 
             console.log(`Signed transaction: ${signature}!`);
         } catch (e) {


### PR DESCRIPTION
Adds a `sendTransaction` helper to `useMobileWallet` to simplify transaction signing and sending in React Native.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `sendTransaction` helper to `useMobileWallet` for simplified transaction handling in React Native.
> 
>   - **Behavior**:
>     - Adds `sendTransaction` helper to `useMobileWallet` in `use-mobile-wallet.ts` for transaction signing and sending.
>     - Handles transaction instructions and returns a decoded signature.
>   - **Examples**:
>     - Updates `account-feature-sign-transaction.tsx` to use `sendTransaction` for signing transactions.
>   - **Documentation**:
>     - Adds changeset file `add-send-transaction-hook.md` to document the new feature addition.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=wallet-ui%2Fwallet-ui&utm_source=github&utm_medium=referral)<sup> for 0a0021aa99dff8b9489522262b18254276f4da47. You can [customize](https://app.ellipsis.dev/wallet-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->