### PR TITLE
feat(react-native-kit): sign in should return message and signature

### DIFF
--- a/.changeset/fluffy-bats-taste.md
+++ b/.changeset/fluffy-bats-taste.md
@@ -1,0 +1,6 @@
+---
+'@wallet-ui/react-native-kit': major
+'@wallet-ui/core': major
+---
+
+sign in should return message and signature

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -5,5 +5,6 @@ export * from './create-storage-cluster';
 export * from './get-explorer-url';
 export * from './handle-copy-text';
 export * from './storage';
+export * from './string-to-uint8-array';
 export * from './types/solana-cluster';
 export * from './types/solana-cluster-id';

--- a/packages/core/src/string-to-uint8-array.ts
+++ b/packages/core/src/string-to-uint8-array.ts
@@ -1,0 +1,3 @@
+export function stringToUint8Array(value: Uint8Array | string): Uint8Array {
+    return value instanceof Uint8Array ? value : new TextEncoder().encode(value);
+}

--- a/packages/react-native-kit/src/convert-sign-in-result.ts
+++ b/packages/react-native-kit/src/convert-sign-in-result.ts
@@ -1,0 +1,24 @@
+import { SolanaSignInOutput } from '@solana/wallet-standard-features';
+import { SignInResult } from '@solana-mobile/mobile-wallet-adapter-protocol';
+import { stringToUint8Array } from '@wallet-ui/core';
+
+import { Account } from './use-authorization';
+
+export type SignInOutput = Omit<SolanaSignInOutput, 'account' | 'signatureType'> &
+    Readonly<{
+        account: Account;
+    }>;
+
+export function convertSignInResult({
+    account,
+    signInResult,
+}: {
+    account: Account;
+    signInResult: SignInResult;
+}): SignInOutput {
+    return {
+        account,
+        signature: stringToUint8Array(signInResult.signature),
+        signedMessage: stringToUint8Array(signInResult.signed_message),
+    };
+}

--- a/packages/react-native-kit/src/index.ts
+++ b/packages/react-native-kit/src/index.ts
@@ -10,3 +10,4 @@ export * from '@wallet-ui/core';
 export { toUint8Array, fromUint8Array } from 'js-base64';
 export { createDefaultClient } from './create-default-client';
 export type { Client } from './client';
+export { convertSignInResult } from './convert-sign-in-result';

--- a/packages/react-native-kit/src/use-mobile-wallet.ts
+++ b/packages/react-native-kit/src/use-mobile-wallet.ts
@@ -15,6 +15,7 @@ import { AuthorizeAPI, SignInPayload } from '@solana-mobile/mobile-wallet-adapte
 import { transact } from '@solana-mobile/mobile-wallet-adapter-protocol-kit';
 import { useCallback, useContext, useMemo } from 'react';
 
+import { SignInOutput } from './convert-sign-in-result';
 import { MobileWalletProviderContext } from './mobile-wallet-provider';
 import { TransactionSignatures } from './types';
 import { Account, useAuthorization } from './use-authorization';
@@ -44,7 +45,7 @@ export function useMobileWallet() {
     );
 
     const signIn = useCallback(
-        async (signInPayload: SignInPayload): Promise<Account> =>
+        async (signInPayload: SignInPayload): Promise<SignInOutput> =>
             await transact(async wallet => await authorizeSessionWithSignIn(wallet, signInPayload)),
         [authorizeSessionWithSignIn],
     );

--- a/turbo.json
+++ b/turbo.json
@@ -43,7 +43,16 @@
                 "test:treeshakability:native",
                 "test:treeshakability:node"
             ],
-            "passThroughEnv": ["ACTIONS_ID_TOKEN_REQUEST_TOKEN", "ACTIONS_ID_TOKEN_REQUEST_URL", "GH_TOKEN", "GITHUB_*", "NODE_AUTH_TOKEN", "NPM_CONFIG_USERCONFIG", "NPM_TOKEN", "PUBLISH_TAG"]
+            "passThroughEnv": [
+                "ACTIONS_ID_TOKEN_REQUEST_TOKEN",
+                "ACTIONS_ID_TOKEN_REQUEST_URL",
+                "GH_TOKEN",
+                "GITHUB_*",
+                "NODE_AUTH_TOKEN",
+                "NPM_CONFIG_USERCONFIG",
+                "NPM_TOKEN",
+                "PUBLISH_TAG"
+            ]
         },
         "style:fix": {
             "inputs": ["$TURBO_DEFAULT$", "*"],


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Enhance `authorizeSessionWithSignIn` to return message and signature, updating `signIn` accordingly.
> 
>   - **Behavior**:
>     - `authorizeSessionWithSignIn` in `use-authorization.ts` now returns an object with `account`, `message`, and `signature`.
>     - Handles missing `sign_in_result` by throwing an error.
>   - **Functions**:
>     - Update `signIn` in `use-mobile-wallet.ts` to return `{ account, message, signature }` instead of just `Account`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=wallet-ui%2Fwallet-ui&utm_source=github&utm_medium=referral)<sup> for 9ea8831138ba4242c0a379adf4732c0376d1e621. You can [customize](https://app.ellipsis.dev/wallet-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->