### PR TITLE
fix: set registry-url in actions/setup-node

### DIFF
--- a/.github/workflows/actions/install-dependencies/action.yml
+++ b/.github/workflows/actions/install-dependencies/action.yml
@@ -10,15 +10,16 @@ runs:
   using: composite
   steps:
     - name: Install package manager
-      uses: pnpm/action-setup@v3
+      uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4
       with:
-        version: 10.20.0
+        version: 10.30.2
 
     - name: Setup Node
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
       with:
         node-version: ${{ inputs.version }}
         cache: 'pnpm'
+        registry-url: 'https://registry.npmjs.org'
 
     - name: Install dependencies
       shell: bash

--- a/.github/workflows/actions/setup-validator/action.yml
+++ b/.github/workflows/actions/setup-validator/action.yml
@@ -16,7 +16,7 @@ runs:
 
     - name: Cache Test Validator
       id: cache-test-validator
-      uses: actions/cache@v4
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
       with:
         path: .agave
         key: ${{ runner.os }}-test-validator-${{ steps.get-test-validator-version.outputs.version }}

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
         "pnpm": "^10",
         "yarn": "please-use-pnpm"
     },
-    "packageManager": "pnpm@10.20.0+sha512.cf9998222162dd85864d0a8102e7892e7ba4ceadebbf5a31f9c2fce48dfce317a9c53b9f6464d1ef9042cba2e02ae02a9f7c143a2b438cd93c91840f0192b9dd",
+    "packageManager": "pnpm@10.30.2",
     "pnpm": {
         "overrides": {
             "agadoo>rollup": "^4",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update `pnpm/action-setup` to v4 and set `registry-url` in `actions/setup-node`.
> 
>   - **Actions**:
>     - Update `pnpm/action-setup` from `v3` to `v4` in `action.yml`.
>     - Add `registry-url: 'https://registry.npmjs.org'` to `actions/setup-node` in `action.yml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=wallet-ui%2Fwallet-ui&utm_source=github&utm_medium=referral)<sup> for e24b7dcbf54bfd01ab223ce0efcf3944c343891f. You can [customize](https://app.ellipsis.dev/wallet-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->