### PR TITLE
fix: add env vars to passThroughEnv

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -43,7 +43,7 @@
                 "test:treeshakability:native",
                 "test:treeshakability:node"
             ],
-            "passThroughEnv": ["GH_TOKEN", "NPM_TOKEN", "PUBLISH_TAG"]
+            "passThroughEnv": ["ACTIONS_ID_TOKEN_REQUEST_TOKEN", "ACTIONS_ID_TOKEN_REQUEST_URL", "GH_TOKEN", "GITHUB_*", "NODE_AUTH_TOKEN", "NPM_CONFIG_USERCONFIG", "NPM_TOKEN", "PUBLISH_TAG"]
         },
         "style:fix": {
             "inputs": ["$TURBO_DEFAULT$", "*"],


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add additional environment variables to `passThroughEnv` for `publish-packages` task in `turbo.json`.
> 
>   - **Environment Variables**:
>     - Added `ACTIONS_ID_TOKEN_REQUEST_TOKEN`, `ACTIONS_ID_TOKEN_REQUEST_URL`, `GITHUB_*`, `NODE_AUTH_TOKEN`, `NPM_CONFIG_USERCONFIG` to `passThroughEnv` in `turbo.json` for `publish-packages` task.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=wallet-ui%2Fwallet-ui&utm_source=github&utm_medium=referral)<sup> for b2cf9ac565f7672382e66cae7adfc0ed9e701124. You can [customize](https://app.ellipsis.dev/wallet-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->