### PR TITLE
feat(mwa): enhance `signAndSendTransaction` return type (#430)

### DIFF
--- a/.changeset/moody-islands-own.md
+++ b/.changeset/moody-islands-own.md
@@ -1,0 +1,6 @@
+---
+'@wallet-ui/react-native-web3js': minor
+'@wallet-ui/react-native-kit': minor
+---
+
+enhance signAndSendTransaction return type

--- a/packages/react-native-kit/src/types/index.ts
+++ b/packages/react-native-kit/src/types/index.ts
@@ -1,0 +1,5 @@
+import { SignatureBytes, Transaction } from '@solana/kit';
+
+export type TransactionSignatures<T extends Transaction | Transaction[]> = T extends unknown[]
+    ? SignatureBytes[]
+    : SignatureBytes;

--- a/packages/react-native-web3js/src/types/index.ts
+++ b/packages/react-native-web3js/src/types/index.ts
@@ -1,0 +1,5 @@
+import { Transaction, TransactionSignature, VersionedTransaction } from '@solana/web3.js';
+
+export type TransactionSignatures<
+    T extends (Transaction | VersionedTransaction)[] | Transaction | VersionedTransaction,
+> = T extends unknown[] ? TransactionSignature[] : TransactionSignature;


### PR DESCRIPTION
Narrow return type based on input: single transaction returns a single signature, array of transactions returns an array of signatures. Uses conditional type TransactionSignatures<T> for type-safe inference.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Enhance `signAndSendTransaction` to return type-safe signatures based on input transaction type in `react-native-kit` and `react-native-web3js`.
> 
>   - **Behavior**:
>     - `signAndSendTransaction` now returns a single signature for a single transaction and an array of signatures for an array of transactions.
>     - Uses `TransactionSignatures<T>` for type-safe inference in `use-mobile-wallet.ts` in both `react-native-kit` and `react-native-web3js`.
>   - **Types**:
>     - Adds `TransactionSignatures<T>` type in `types/index.ts` for both `react-native-kit` and `react-native-web3js`.
>   - **Misc**:
>     - Removes unused `SignatureBytes` import in `use-mobile-wallet.ts` in `react-native-kit`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=wallet-ui%2Fwallet-ui&utm_source=github&utm_medium=referral)<sup> for 97d212a3e3c167c63ca18af48d61e3bc055b3d2c. You can [customize](https://app.ellipsis.dev/wallet-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->