### PR TITLE
fix(docs): repair broken React Native docs link causing 404

### DIFF
--- a/docs/src/app/(home)/page.tsx
+++ b/docs/src/app/(home)/page.tsx
@@ -41,7 +41,7 @@ export default function HomePage() {
             />
             <Card
                 title="Getting Started with React Native"
-                href="/docs/react-native/getting-started"
+                href="/docs/react-native/kit/getting-started"
                 description="Get started with Wallet UI for React Native Web3js"
             />
             <p className="text-fd-muted-foreground">


### PR DESCRIPTION
Fix #433 
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes broken React Native docs link in `page.tsx` to prevent 404 errors.
> 
>   - **Behavior**:
>     - Fixes broken link in `page.tsx` from `/docs/react-native/getting-started` to `/docs/react-native/kit/getting-started`.
>   - **Misc**:
>     - Ensures correct navigation to React Native documentation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=wallet-ui%2Fwallet-ui&utm_source=github&utm_medium=referral)<sup> for 2d55f481b64101427574982144996b4daaa1cb39. You can [customize](https://app.ellipsis.dev/wallet-ui/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->