### PR TITLE
fix(react): re-export wallet standard feature helpers

### DIFF
--- a/.changeset/bright-yaks-share.md
+++ b/.changeset/bright-yaks-share.md
@@ -1,0 +1,5 @@
+---
+'@wallet-ui/react': patch
+---
+
+Re-export Wallet Standard feature helpers from `@wallet-ui/react`.

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -79,6 +79,7 @@
         "@solana/wallet-standard-features": "1.3.0",
         "@wallet-standard/core": "1.1.1",
         "@wallet-standard/react": "1.0.1",
+        "@wallet-standard/ui": "1.0.1",
         "@wallet-ui/core": "workspace:*",
         "@zag-js/dialog": "1.24.2",
         "@zag-js/menu": "1.24.2",

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -35,4 +35,13 @@ export * from '@solana/react';
 export * from '@solana/wallet-standard-features';
 export * from '@wallet-standard/core';
 export * from '@wallet-standard/react';
+export {
+    getWalletAccountFeature,
+    getWalletFeature,
+    uiWalletAccountBelongsToUiWallet,
+    type UiWalletHandle,
+    type UiWallet,
+    type UiWalletAccount,
+    uiWalletAccountsAreSame,
+} from '@wallet-standard/ui';
 export * from '@wallet-ui/core';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -842,6 +842,9 @@ importers:
       '@wallet-standard/react':
         specifier: 1.0.1
         version: 1.0.1(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@wallet-standard/ui':
+        specifier: 1.0.1
+        version: 1.0.1
       '@wallet-ui/core':
         specifier: workspace:*
         version: link:../core


### PR DESCRIPTION
Add explicit exports for getWalletFeature and getWalletAccountFeature from @wallet-ui/react.

Declare @wallet-standard/ui directly and add a patch changeset for the release.
