### PR TITLE
fix(docs): enable search indexing on astro site

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -48,13 +48,6 @@ export default defineConfig({
                 {
                     tag: 'meta',
                     attrs: {
-                        name: 'robots',
-                        content: 'noindex, nofollow',
-                    },
-                },
-                {
-                    tag: 'meta',
-                    attrs: {
                         property: 'og:image',
                         content: new URL(defaultSocialImagePath, siteUrl).toString(),
                     },

--- a/docs/public/robots.txt
+++ b/docs/public/robots.txt
@@ -1,2 +1,0 @@
-User-agent: *
-Disallow: /

--- a/docs/src/pages/robots.txt.ts
+++ b/docs/src/pages/robots.txt.ts
@@ -1,0 +1,17 @@
+import type { APIRoute } from 'astro';
+import { canIndexHost, siteUrl } from '../site-meta.mjs';
+
+export const prerender = false;
+
+export const GET: APIRoute = ({ request }) => {
+    const { hostname } = new URL(request.url);
+    const body = canIndexHost(hostname)
+        ? `User-agent: *\nAllow: /\n\nSitemap: ${new URL('/sitemap-index.xml', siteUrl).toString()}\n`
+        : 'User-agent: *\nDisallow: /\n';
+
+    return new Response(body, {
+        headers: {
+            'content-type': 'text/plain; charset=utf-8',
+        },
+    });
+};

--- a/docs/src/site-meta.mjs
+++ b/docs/src/site-meta.mjs
@@ -3,3 +3,16 @@ export const siteName = 'Wallet UI';
 export const siteDescription = 'The wallet layer for Solana apps on web and mobile.';
 export const defaultSocialImagePath = '/og.png';
 export const defaultSocialImageAlt = 'Wallet UI documentation social card';
+export const indexableHosts = new Set(['wallet-ui.dev', 'www.wallet-ui.dev']);
+
+/**
+ * @param {string | undefined | null} hostname The hostname to check.
+ * @returns {boolean} Whether the host is permitted to be indexed.
+ */
+export function canIndexHost(hostname) {
+    if (typeof hostname !== 'string') {
+        return false;
+    }
+
+    return indexableHosts.has(hostname.toLowerCase());
+}

--- a/docs/src/starlight-route-data.ts
+++ b/docs/src/starlight-route-data.ts
@@ -1,5 +1,5 @@
 import { defineRouteMiddleware } from '@astrojs/starlight/route-data';
-import { siteDescription } from './site-meta.mjs';
+import { canIndexHost, siteDescription } from './site-meta.mjs';
 import {
     formatSocialTitle,
     getDocsSocialImagePath,
@@ -14,6 +14,7 @@ export const onRequest = defineRouteMiddleware(async (context, next) => {
 
     const { entry, head } = context.locals.starlightRoute;
     const pageDescription = entry.data.description ?? siteDescription;
+    const robotsContent = canIndexHost(context.url.hostname) ? 'index, follow' : 'noindex, nofollow';
     const socialTitle = formatSocialTitle(entry.data.title);
     const socialImagePath = getDocsSocialImagePath(normalizeDocsSlug(entry.id));
     const socialImageUrl = new URL(socialImagePath, context.site ?? context.url).toString();
@@ -25,6 +26,7 @@ export const onRequest = defineRouteMiddleware(async (context, next) => {
     setMeta(head, 'property', 'og:image:alt', socialImageAlt);
     setMeta(head, 'property', 'og:image:width', String(socialImageWidth));
     setMeta(head, 'property', 'og:image:height', String(socialImageHeight));
+    setMeta(head, 'name', 'robots', robotsContent);
     setMeta(head, 'name', 'twitter:title', socialTitle);
     setMeta(head, 'name', 'twitter:description', pageDescription);
     setMeta(head, 'name', 'twitter:image', socialImageUrl);


### PR DESCRIPTION
## Summary
- remove the temporary `noindex, nofollow` meta from the Astro docs site
- allow crawling in `docs/public/robots.txt` and publish the sitemap URL
- keep the site canonical pointed at `https://wallet-ui.dev` for the final domain

## Verification
- `pnpm --filter @wallet-ui/docs build`
- `cd docs && node scripts/check-dead-links.mjs`
