### PR TITLE
fix(docs): codify docs domain routing

### DIFF
--- a/docs/wrangler.toml
+++ b/docs/wrangler.toml
@@ -1,6 +1,7 @@
 name = "wallet-ui-docs"
 compatibility_date = "2026-03-29"
 compatibility_flags = ["nodejs_compat"]
+workers_dev = false
 
 [observability]
 enabled = true
@@ -8,3 +9,7 @@ enabled = true
 [assets]
 directory = "./dist"
 not_found_handling = "404-page"
+
+[[routes]]
+pattern = "wallet-ui.dev"
+custom_domain = true


### PR DESCRIPTION
Disable workers.dev for the docs worker in Wrangler config.

Declare wallet-ui.dev as the custom domain in source control so deploys and dashboard state stay aligned.
