### PR TITLE
fix(docs): restore preview URLs

### DIFF
--- a/docs/wrangler.toml
+++ b/docs/wrangler.toml
@@ -2,6 +2,7 @@ name = "wallet-ui-docs"
 compatibility_date = "2026-03-29"
 compatibility_flags = ["nodejs_compat"]
 workers_dev = false
+preview_urls = true
 
 [observability]
 enabled = true


### PR DESCRIPTION
Keep the docs worker off the public workers.dev production hostname while re-enabling Cloudflare preview URLs.

This preserves wallet-ui.dev as the pinned custom domain and brings branch/version previews back for docs review flows.
