### PR TITLE
chore: update pnpm to v10.33.0

### DIFF
--- a/.github/workflows/actions/install-dependencies/action.yml
+++ b/.github/workflows/actions/install-dependencies/action.yml
@@ -12,7 +12,7 @@ runs:
     - name: Install package manager
       uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4
       with:
-        version: 10.30.2
+        version: 10.33.0
 
     - name: Setup Node
       uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
         "pnpm": "^10",
         "yarn": "please-use-pnpm"
     },
-    "packageManager": "pnpm@10.30.2",
+    "packageManager": "pnpm@10.33.0",
     "pnpm": {
         "overrides": {
             "agadoo>rollup": "^4",


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wallet-ui/wallet-ui/pull/475" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the pinned package manager to pnpm 10.33.0 in project metadata.
  * CI and install tooling now use pnpm 10.33.0 to keep installs and builds consistent across environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->