### PR TITLE
test(react-native): add unit tests for kit and web3js

### DIFF
--- a/.ruler/project.md
+++ b/.ruler/project.md
@@ -42,6 +42,24 @@ Run these commands from the root directory:
 - **Run Live Tests**: `pnpm test:live-with-test-validator`
 - Prefix turbo commands with `FORCE=true` when you need uncached results during verification or debugging.
 
+## Testing Guidance
+
+### General
+
+- **Direct inline assertions**: Prefer direct `expect(...)` calls in the test body over custom assertion helpers when writing Jest tests. This keeps paired suites easier to compare and avoids `jest/expect-expect` false negatives.
+- **Dual-environment verification**: For package-level test work, treat `test:unit:browser`, `test:unit:node`, `test:lint`, and `test:typecheck` as the normal verification set.
+- **Explicit assertion counts**: When adding or refactoring Jest tests with async or mock-heavy control flow, start each test with `expect.assertions(n)` so the expected assertion count is visible in the test itself.
+- **Import-first test files**: Prefer normal imports first in Jest test files when the current setup supports it. This repo's Jest setup hoists `jest.mock(...)`, so readability wins unless a specific file proves otherwise.
+- **Package-scoped iteration**: Prefer `pnpm --filter <package> ...` commands while iterating so verification stays fast and scoped to the package under change.
+
+### React Native Packages
+
+- **AsyncStorage and native mocks**: Mock React Native native modules and the Solana Mobile transport boundary in unit tests so the suites never depend on real native implementations.
+- **Package-local hook renderers**: Keep `react-test-renderer`-based hook helpers under each React Native package's `src/test-utils` so `react` and `react-test-renderer` resolve from the package under test instead of from `packages/test-config`.
+- **Shared RN test utilities**: Keep version-insensitive helpers such as `resetAsyncStorageMock` in `packages/test-config/react-native-unit-test-utils.tsx` so shared native-module mock reset logic stays centralized without reintroducing cross-package React resolution.
+- **Surface-specific coverage**: Add package-specific tests only when the runtime API truly differs. Current examples: `@wallet-ui/react-native-kit` exposes `getTransactionSigner`, `sendTransaction`, and `sendTransactions`, while `@wallet-ui/react-native-web3js` exposes `PublicKey`-specific account behavior.
+- **Symmetric paired suites**: Keep matching `@wallet-ui/react-native-kit` and `@wallet-ui/react-native-web3js` tests as mechanically similar as possible. Use the same fixture names, assertion style, and test ordering, and isolate only real API differences into dedicated package-specific tests.
+
 ### Clean Checkout Build Notes
 
 - Example apps are **not** standalone from a pristine checkout. Workspace packages such as `@wallet-ui/react` and `@wallet-ui/playground-react` export built `dist/` artifacts, so a direct example build can fail before prerendering if those workspace packages have not been compiled yet.

--- a/packages/react-native-kit/src/__tests__/authorization-store-test.ts
+++ b/packages/react-native-kit/src/__tests__/authorization-store-test.ts
@@ -1,0 +1,48 @@
+import { createAuthorizationStore } from '../authorization-store';
+import { createCache, createExpectedAuthorization } from '../test-utils/fixtures';
+
+describe('authorization-store', () => {
+    it('loads authorization from the cache and exposes computed values', async () => {
+        expect.assertions(4);
+        const authorization = createExpectedAuthorization();
+        const cache = createCache({
+            get: jest.fn().mockResolvedValue(authorization),
+        });
+        const store = createAuthorizationStore({ cache });
+
+        await expect(store.fetch()).resolves.toBe(authorization);
+        expect(store.$accounts.get()).toBe(authorization.accounts);
+        expect(store.$authToken.get()).toBe(authorization.authToken);
+        expect(store.$selectedAccount.get()).toBe(authorization.selectedAccount);
+    });
+
+    it('persists authorization to the cache and exposes computed values', async () => {
+        expect.assertions(5);
+        const authorization = createExpectedAuthorization();
+        const cache = createCache();
+        const store = createAuthorizationStore({ cache });
+
+        await store.persist(authorization);
+
+        expect(cache.set).toHaveBeenCalledWith(authorization);
+        expect(cache.clear).not.toHaveBeenCalled();
+        expect(store.$accounts.get()).toBe(authorization.accounts);
+        expect(store.$authToken.get()).toBe(authorization.authToken);
+        expect(store.$selectedAccount.get()).toBe(authorization.selectedAccount);
+    });
+
+    it('clears authorization from the cache and resets computed values', async () => {
+        expect.assertions(4);
+        const authorization = createExpectedAuthorization();
+        const cache = createCache();
+        const store = createAuthorizationStore({ cache });
+
+        await store.persist(authorization);
+        await store.persist(null);
+
+        expect(cache.clear).toHaveBeenCalledTimes(1);
+        expect(store.$accounts.get()).toBeNull();
+        expect(store.$authToken.get()).toBeUndefined();
+        expect(store.$selectedAccount.get()).toBeUndefined();
+    });
+});

--- a/packages/react-native-kit/src/__tests__/dummy-test.ts
+++ b/packages/react-native-kit/src/__tests__/dummy-test.ts
@@ -1,5 +1,0 @@
-describe('dummy', () => {
-    it('should return something', () => {
-        expect(true).toBe(true);
-    });
-});

--- a/packages/react-native-kit/src/__tests__/helpers-test.ts
+++ b/packages/react-native-kit/src/__tests__/helpers-test.ts
@@ -1,0 +1,129 @@
+import { convertSignInResult } from '../convert-sign-in-result';
+import { getAccountFromAuthorizedAccount } from '../get-account-from-authorized-account';
+import { getAuthorizationFromAuthorizationResult } from '../get-authorization-from-authorization-result';
+import {
+    createAuthorizationResult,
+    createAuthorizedAccount,
+    createExpectedAccount,
+    createExpectedAuthorization,
+    createExpectedSignInOutput,
+    createSignInResult,
+    FIRST_ADDRESS,
+    FIRST_ADDRESS_BASE64,
+    ICON,
+    SECOND_ADDRESS,
+    SECOND_ADDRESS_BASE64,
+} from '../test-utils/fixtures';
+
+describe('react-native-kit helpers', () => {
+    it('converts an authorized account into a wallet-ui account', () => {
+        expect.assertions(1);
+        const authorizedAccount = createAuthorizedAccount({
+            address: FIRST_ADDRESS_BASE64,
+            icon: ICON,
+            label: 'Primary',
+        });
+        const account = getAccountFromAuthorizedAccount(authorizedAccount);
+
+        expect(account).toEqual(
+            createExpectedAccount({
+                address: FIRST_ADDRESS,
+                addressBase64: FIRST_ADDRESS_BASE64,
+                icon: ICON,
+                label: 'Primary',
+            }),
+        );
+    });
+
+    it('falls back to the first account when the previously selected account is no longer authorized', () => {
+        expect.assertions(1);
+        const previousSelection = getAccountFromAuthorizedAccount(
+            createAuthorizedAccount({
+                address: FIRST_ADDRESS_BASE64,
+            }),
+        );
+        const authorization = getAuthorizationFromAuthorizationResult(
+            createAuthorizationResult({
+                accounts: [
+                    createAuthorizedAccount({
+                        address: SECOND_ADDRESS_BASE64,
+                    }),
+                ],
+            }),
+            previousSelection,
+        );
+
+        expect(authorization).toEqual(
+            createExpectedAuthorization({
+                accounts: [
+                    createExpectedAccount({
+                        address: SECOND_ADDRESS,
+                        addressBase64: SECOND_ADDRESS_BASE64,
+                        label: 'Stake111..11111111',
+                    }),
+                ],
+                authToken: 'next-auth-token',
+            }),
+        );
+    });
+
+    it('keeps the previous selection when it is still present in the authorization result', () => {
+        expect.assertions(2);
+        const previousSelection = getAccountFromAuthorizedAccount(
+            createAuthorizedAccount({
+                address: SECOND_ADDRESS_BASE64,
+                label: 'Stake account',
+            }),
+        );
+        const authorization = getAuthorizationFromAuthorizationResult(
+            createAuthorizationResult({
+                accounts: [
+                    createAuthorizedAccount({
+                        address: FIRST_ADDRESS_BASE64,
+                    }),
+                    createAuthorizedAccount({
+                        address: SECOND_ADDRESS_BASE64,
+                        label: 'Stake account',
+                    }),
+                ],
+            }),
+            previousSelection,
+        );
+
+        expect(authorization.selectedAccount).toBe(previousSelection);
+        expect(authorization.accounts).toEqual([
+            createExpectedAccount({
+                address: FIRST_ADDRESS,
+                addressBase64: FIRST_ADDRESS_BASE64,
+                label: '11111111..11111111',
+            }),
+            createExpectedAccount({
+                address: SECOND_ADDRESS,
+                addressBase64: SECOND_ADDRESS_BASE64,
+                label: 'Stake account',
+            }),
+        ]);
+    });
+
+    it('normalizes the sign-in result into Uint8Array payloads', () => {
+        expect.assertions(1);
+        const account = getAccountFromAuthorizedAccount(
+            createAuthorizedAccount({
+                address: FIRST_ADDRESS_BASE64,
+                label: 'Primary',
+            }),
+        );
+        const signInResult = createSignInResult();
+
+        expect(convertSignInResult({ account, signInResult })).toEqual(
+            createExpectedSignInOutput({
+                account: createExpectedAccount({
+                    address: FIRST_ADDRESS,
+                    addressBase64: FIRST_ADDRESS_BASE64,
+                    label: 'Primary',
+                }),
+                signInResult,
+            }),
+        );
+    });
+});

--- a/packages/react-native-kit/src/__tests__/index-test.ts
+++ b/packages/react-native-kit/src/__tests__/index-test.ts
@@ -1,0 +1,28 @@
+import { createAuthorizationStore } from '../authorization-store';
+import { convertSignInResult } from '../convert-sign-in-result';
+import * as reactNativeKit from '../index';
+import { MobileWalletProvider, MobileWalletProviderContext } from '../mobile-wallet-provider';
+import { useAuthorization } from '../use-authorization';
+import { useMobileWallet } from '../use-mobile-wallet';
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+    __esModule: true,
+    default: {
+        getItem: jest.fn(),
+        removeItem: jest.fn(),
+        setItem: jest.fn(),
+    },
+}));
+
+describe('index', () => {
+    it('re-exports the local runtime surface from the barrel', () => {
+        expect.assertions(6);
+
+        expect(reactNativeKit.MobileWalletProvider).toBe(MobileWalletProvider);
+        expect(reactNativeKit.MobileWalletProviderContext).toBe(MobileWalletProviderContext);
+        expect(reactNativeKit.convertSignInResult).toBe(convertSignInResult);
+        expect(reactNativeKit.createAuthorizationStore).toBe(createAuthorizationStore);
+        expect(reactNativeKit.useAuthorization).toBe(useAuthorization);
+        expect(reactNativeKit.useMobileWallet).toBe(useMobileWallet);
+    });
+});

--- a/packages/react-native-kit/src/__tests__/mobile-wallet-provider-test.tsx
+++ b/packages/react-native-kit/src/__tests__/mobile-wallet-provider-test.tsx
@@ -1,0 +1,114 @@
+import { AppIdentity } from '@solana-mobile/mobile-wallet-adapter-protocol';
+import React, { type ReactNode, useContext } from 'react';
+
+import { act, renderHook } from '../test-utils/react-test-renderer';
+import { createAsyncStorageCache } from '../async-storage-cache';
+import type { Cache } from '../cache';
+import type { Client } from '../client';
+import { MobileWalletProvider, MobileWalletProviderContext } from '../mobile-wallet-provider';
+import { createCache } from '../test-utils/fixtures';
+import type { WalletAuthorization } from '../use-authorization';
+
+jest.mock('../async-storage-cache', () => ({
+    createAsyncStorageCache: jest.fn(),
+}));
+
+const mockCreateAsyncStorageCache = jest.mocked(createAsyncStorageCache);
+const CLUSTER = {
+    id: 'solana:devnet',
+    url: 'https://rpc.wallet-ui.dev',
+    urlWs: 'wss://rpc.wallet-ui.dev',
+} as const;
+const IDENTITY = {
+    name: 'Wallet UI',
+    uri: 'https://wallet-ui.dev',
+} as AppIdentity;
+
+describe('MobileWalletProvider', () => {
+    beforeEach(() => {
+        mockCreateAsyncStorageCache.mockReset();
+    });
+
+    it('uses the provided cache and client factory and fetches authorization on mount', async () => {
+        expect.assertions(8);
+        const cache = createCache();
+        const client = createClient();
+        const createClientFactory = jest.fn().mockReturnValue(client);
+        const hook = renderHook(useProviderState, {
+            initialProps: undefined,
+            wrapper: createProviderWrapper({
+                cache,
+                createClient: createClientFactory,
+            }),
+        });
+
+        await act(async () => {
+            await Promise.resolve();
+        });
+
+        expect(createClientFactory).toHaveBeenCalledWith(CLUSTER);
+        expect(mockCreateAsyncStorageCache).not.toHaveBeenCalled();
+        expect(cache.get).toHaveBeenCalledTimes(1);
+        expect(hook.result.cache).toBe(cache);
+        expect(hook.result.chain).toBe(CLUSTER.id);
+        expect(hook.result.client).toBe(client);
+        expect(hook.result.identity).toBe(IDENTITY);
+        expect(hook.result.store).toEqual(expect.objectContaining({ fetch: expect.any(Function), persist: expect.any(Function) }));
+    });
+
+    it('creates a default cache when one is not provided', async () => {
+        expect.assertions(6);
+        const cache = createCache();
+        const client = createClient();
+        const createClientFactory = jest.fn().mockReturnValue(client);
+
+        mockCreateAsyncStorageCache.mockReturnValue(cache as never);
+
+        const hook = renderHook(useProviderState, {
+            initialProps: undefined,
+            wrapper: createProviderWrapper({
+                createClient: createClientFactory,
+            }),
+        });
+
+        await act(async () => {
+            await Promise.resolve();
+        });
+
+        expect(mockCreateAsyncStorageCache).toHaveBeenCalledTimes(1);
+        expect(createClientFactory).toHaveBeenCalledWith(CLUSTER);
+        expect(cache.get).toHaveBeenCalledTimes(1);
+        expect(hook.result.cache).toBe(cache);
+        expect(hook.result.client).toBe(client);
+        expect(hook.result.identity).toBe(IDENTITY);
+    });
+});
+
+function createClient(): Client {
+    return {
+        rpc: {
+            getLatestBlockhash: jest.fn(),
+        } as never,
+        rpcSubscriptions: {} as never,
+    };
+}
+
+function createProviderWrapper({
+    cache,
+    createClient,
+}: {
+    cache?: Cache<WalletAuthorization | undefined>;
+    createClient?: (cluster: { url: string; urlWs?: string }) => Client;
+}) {
+    return function ProviderWrapper({ children }: { children: unknown }) {
+        return (
+            <MobileWalletProvider cache={cache} cluster={CLUSTER} createClient={createClient} identity={IDENTITY}>
+                {children as ReactNode}
+            </MobileWalletProvider>
+        );
+    };
+}
+
+function useProviderState(_: undefined) {
+    return useContext(MobileWalletProviderContext);
+}

--- a/packages/react-native-kit/src/__tests__/use-authorization-store-test.tsx
+++ b/packages/react-native-kit/src/__tests__/use-authorization-store-test.tsx
@@ -1,0 +1,37 @@
+import { act, renderHook } from '../test-utils/react-test-renderer';
+import { createAuthorizationStore } from '../authorization-store';
+import { createCache, createExpectedAuthorization } from '../test-utils/fixtures';
+import { useAuthorizationStore } from '../use-authorization-store';
+
+describe('useAuthorizationStore', () => {
+    it('returns the empty authorization state before any authorization is loaded', () => {
+        expect.assertions(4);
+        const store = createAuthorizationStore({ cache: createCache() });
+        const hook = renderHook(useAuthorizationStore, {
+            initialProps: { store },
+        });
+
+        expect(hook.result.accounts).toBeNull();
+        expect(hook.result.authToken).toBeUndefined();
+        expect(hook.result.persist).toBe(store.persist);
+        expect(hook.result.selectedAccount).toBeUndefined();
+    });
+
+    it('updates when the authorization store changes', async () => {
+        expect.assertions(4);
+        const authorization = createExpectedAuthorization();
+        const store = createAuthorizationStore({ cache: createCache() });
+        const hook = renderHook(useAuthorizationStore, {
+            initialProps: { store },
+        });
+
+        await act(async () => {
+            await store.persist(authorization);
+        });
+
+        expect(hook.result.accounts).toBe(authorization.accounts);
+        expect(hook.result.authToken).toBe(authorization.authToken);
+        expect(hook.result.persist).toBe(store.persist);
+        expect(hook.result.selectedAccount).toBe(authorization.selectedAccount);
+    });
+});

--- a/packages/react-native-kit/src/__tests__/use-authorization-test.tsx
+++ b/packages/react-native-kit/src/__tests__/use-authorization-test.tsx
@@ -1,0 +1,243 @@
+import {
+    AppIdentity,
+    AuthorizeAPI,
+    Chain,
+    DeauthorizeAPI,
+    SignInPayload,
+    SolanaMobileWalletAdapterProtocolError,
+    SolanaMobileWalletAdapterProtocolErrorCode,
+} from '@solana-mobile/mobile-wallet-adapter-protocol';
+
+import {
+    createAuthorizedAccount,
+    createAuthorizationResult,
+    createExpectedAccount,
+    createExpectedAuthorization,
+    createExpectedSignInOutput,
+    createSignInResult,
+    FIRST_ADDRESS,
+    SECOND_ADDRESS,
+    SECOND_ADDRESS_BASE64,
+} from '../test-utils/fixtures';
+import type { WalletAuthorization } from '../use-authorization';
+import { useAuthorization } from '../use-authorization';
+
+const mockUseAuthorizationStore = jest.fn();
+
+jest.mock('react', () => {
+    const actual = jest.requireActual('react');
+
+    return {
+        ...actual,
+        useCallback: (callback: unknown) => callback,
+        useMemo: (factory: () => unknown) => factory(),
+    };
+});
+
+jest.mock('../use-authorization-store', () => ({
+    useAuthorizationStore: (...args: unknown[]) => mockUseAuthorizationStore(...args),
+}));
+
+const CHAIN = 'solana:devnet' as Chain;
+const IDENTITY = {
+    name: 'Wallet UI',
+    uri: 'https://wallet-ui.dev',
+} as AppIdentity;
+
+describe('useAuthorization', () => {
+    it('authorizes with the existing auth token and persists the selected authorization', async () => {
+        expect.assertions(3);
+        const { authorization, persist } = useAuthorizationTestHarness();
+        const wallet = createWallet({
+            authorize: jest.fn().mockResolvedValue(
+                createAuthorizationResult({
+                    accounts: [
+                        createAuthorizedAccount({
+                            address: SECOND_ADDRESS_BASE64,
+                            label: 'Stake account',
+                        }),
+                    ],
+                    authToken: 'next-auth-token',
+                }),
+            ),
+        });
+
+        const selectedAccount = await authorization.authorizeSession(wallet as AuthorizeAPI);
+
+        expect(wallet.authorize).toHaveBeenCalledWith({
+            auth_token: 'cached-auth-token',
+            chain: CHAIN,
+            identity: IDENTITY,
+        });
+        expect(lastPersistedAuthorization(persist)).toEqual(
+            createExpectedAuthorization({
+                accounts: [
+                    createExpectedAccount({
+                        address: SECOND_ADDRESS,
+                        addressBase64: SECOND_ADDRESS_BASE64,
+                        label: 'Stake account',
+                    }),
+                ],
+                authToken: 'next-auth-token',
+            }),
+        );
+        expect(selectedAccount).toEqual(
+            createExpectedAccount({
+                address: SECOND_ADDRESS,
+                addressBase64: SECOND_ADDRESS_BASE64,
+                label: 'Stake account',
+            }),
+        );
+    });
+
+    it('retries without the cached auth token when authorization fails', async () => {
+        expect.assertions(2);
+        const { authorization, persist } = useAuthorizationTestHarness();
+        const wallet = createWallet({
+            authorize: jest
+                .fn()
+                .mockRejectedValueOnce(
+                    new SolanaMobileWalletAdapterProtocolError(
+                        1,
+                        SolanaMobileWalletAdapterProtocolErrorCode.ERROR_AUTHORIZATION_FAILED,
+                        'Authorization failed',
+                    ),
+                )
+                .mockResolvedValueOnce(
+                    createAuthorizationResult({
+                        accounts: [
+                            createAuthorizedAccount({
+                                address: SECOND_ADDRESS_BASE64,
+                            }),
+                        ],
+                        authToken: 'retried-auth-token',
+                    }),
+                ),
+        });
+
+        await authorization.authorizeSession(wallet as AuthorizeAPI);
+
+        expect(wallet.authorize.mock.calls).toEqual([
+            [
+                {
+                    auth_token: 'cached-auth-token',
+                    chain: CHAIN,
+                    identity: IDENTITY,
+                },
+            ],
+            [
+                {
+                    chain: CHAIN,
+                    identity: IDENTITY,
+                },
+            ],
+        ]);
+        expect(lastPersistedAuthorization(persist)).toEqual(
+            createExpectedAuthorization({
+                accounts: [
+                    createExpectedAccount({
+                        address: SECOND_ADDRESS,
+                        addressBase64: SECOND_ADDRESS_BASE64,
+                        label: 'Stake111..11111111',
+                    }),
+                ],
+                authToken: 'retried-auth-token',
+            }),
+        );
+    });
+
+    it('returns a normalized sign-in result and persists the next authorization', async () => {
+        expect.assertions(3);
+        const { authorization, persist } = useAuthorizationTestHarness();
+        const signInPayload = {
+            address: FIRST_ADDRESS,
+            domain: 'wallet-ui.dev',
+        } as SignInPayload;
+        const signInResult = createSignInResult();
+        const wallet = createWallet({
+            authorize: jest.fn().mockResolvedValue(
+                createAuthorizationResult({
+                    authToken: 'signed-in-auth-token',
+                    signInResult,
+                }),
+            ),
+        });
+
+        const output = await authorization.authorizeSessionWithSignIn(wallet as AuthorizeAPI, signInPayload);
+
+        expect(wallet.authorize).toHaveBeenCalledWith({
+            auth_token: 'cached-auth-token',
+            chain: CHAIN,
+            identity: IDENTITY,
+            sign_in_payload: signInPayload,
+        });
+        expect(lastPersistedAuthorization(persist)).toEqual(
+            createExpectedAuthorization({
+                authToken: 'signed-in-auth-token',
+            }),
+        );
+        expect(output).toEqual(
+            createExpectedSignInOutput({
+                account: createExpectedAccount(),
+                signInResult,
+            }),
+        );
+    });
+
+    it('deauthorizes the current session and clears persisted state', async () => {
+        expect.assertions(2);
+        const { authorization, persist } = useAuthorizationTestHarness();
+        const wallet = createWallet({
+            deauthorize: jest.fn().mockResolvedValue(undefined),
+        });
+
+        await authorization.deauthorizeSession(wallet as DeauthorizeAPI);
+
+        expect(wallet.deauthorize).toHaveBeenCalledWith({
+            auth_token: 'cached-auth-token',
+        });
+        expect(persist).toHaveBeenCalledWith(null);
+    });
+
+    it('clears persisted state without a wallet round-trip when deauthorizing all sessions', async () => {
+        expect.assertions(1);
+        const { authorization, persist } = useAuthorizationTestHarness();
+
+        await authorization.deauthorizeSessions();
+
+        expect(persist).toHaveBeenCalledWith(null);
+    });
+});
+
+function createWallet({
+    authorize = jest.fn(),
+    deauthorize = jest.fn(),
+}: {
+    authorize?: jest.Mock;
+    deauthorize?: jest.Mock;
+} = {}) {
+    return {
+        authorize,
+        deauthorize,
+    };
+}
+
+function lastPersistedAuthorization(persist: jest.Mock): WalletAuthorization {
+    return persist.mock.calls.at(-1)?.[0] as WalletAuthorization;
+}
+
+function useAuthorizationTestHarness() {
+    const persist = jest.fn().mockResolvedValue(undefined);
+
+    mockUseAuthorizationStore.mockReturnValue({
+        accounts: [createExpectedAccount()],
+        authToken: 'cached-auth-token',
+        persist,
+        selectedAccount: createExpectedAccount(),
+    });
+
+    return {
+        authorization: useAuthorization({ chain: CHAIN, identity: IDENTITY, store: {} as never }),
+        persist,
+    };
+}

--- a/packages/react-native-kit/src/__tests__/use-mobile-wallet-test.tsx
+++ b/packages/react-native-kit/src/__tests__/use-mobile-wallet-test.tsx
@@ -1,0 +1,345 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+import { resetAsyncStorageMock } from '../../../test-config/react-native-unit-test-utils';
+import { createExpectedAccount, FIRST_ADDRESS, FIRST_ADDRESS_BASE64 } from '../test-utils/fixtures';
+import { useMobileWallet } from '../use-mobile-wallet';
+
+let currentContext: unknown;
+
+const mockAppendTransactionMessageInstructions = jest.fn();
+const mockAuthorizeSession = jest.fn();
+const mockAuthorizeSessionWithSignIn = jest.fn();
+const mockCreateTransactionMessage = jest.fn();
+const mockDecodeBase58 = jest.fn();
+const mockDeauthorizeSession = jest.fn();
+const mockDeauthorizeSessions = jest.fn();
+const mockPipe = jest.fn();
+const mockSetTransactionMessageFeePayerSigner = jest.fn();
+const mockSetTransactionMessageLifetimeUsingBlockhash = jest.fn();
+const mockSignAndSendTransactionMessageWithSigners = jest.fn();
+const mockTransact = jest.fn();
+const mockUseAuthorization = jest.fn();
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+    __esModule: true,
+    default: {
+        getItem: jest.fn(),
+        removeItem: jest.fn(),
+        setItem: jest.fn(),
+    },
+}));
+
+jest.mock('react', () => {
+    const actual = jest.requireActual('react');
+
+    return {
+        ...actual,
+        useCallback: (callback: unknown) => callback,
+        useContext: () => currentContext,
+        useMemo: (factory: () => unknown) => factory(),
+    };
+});
+
+jest.mock('@solana-mobile/mobile-wallet-adapter-protocol-kit', () => ({
+    transact: (...args: unknown[]) => mockTransact(...args),
+}));
+
+jest.mock('@solana/kit', () => ({
+    appendTransactionMessageInstructions: (...args: unknown[]) => mockAppendTransactionMessageInstructions(...args),
+    createTransactionMessage: (...args: unknown[]) => mockCreateTransactionMessage(...args),
+    getBase58Decoder: () => ({
+        decode: (...args: unknown[]) => mockDecodeBase58(...args),
+    }),
+    pipe: (...args: unknown[]) => mockPipe(...args),
+    setTransactionMessageFeePayerSigner: (...args: unknown[]) => mockSetTransactionMessageFeePayerSigner(...args),
+    setTransactionMessageLifetimeUsingBlockhash: (...args: unknown[]) =>
+        mockSetTransactionMessageLifetimeUsingBlockhash(...args),
+    signAndSendTransactionMessageWithSigners: (...args: unknown[]) =>
+        mockSignAndSendTransactionMessageWithSigners(...args),
+}));
+
+jest.mock('../use-authorization', () => ({
+    useAuthorization: (...args: unknown[]) => mockUseAuthorization(...args),
+}));
+
+describe('useMobileWallet', () => {
+    it('connects through the transport and returns the selected account', async () => {
+        expect.assertions(3);
+        const { mobileWallet } = useMobileWalletTestHarness();
+        const account = await mobileWallet.connect();
+
+        expect(mockTransact).toHaveBeenCalledTimes(1);
+        expect(mockAuthorizeSession).toHaveBeenCalledWith(expect.objectContaining({ authorize: expect.any(Function) }));
+        expect(account).toEqual(createExpectedAccount({ label: 'Primary' }));
+    });
+
+    it('passes the transport wallet into connectAnd callbacks', async () => {
+        expect.assertions(3);
+        const callback = jest.fn().mockResolvedValue('connected-via-callback');
+        const transportWallet = createTransportWallet();
+        const { mobileWallet } = useMobileWalletTestHarness({ transportWallet });
+
+        const result = await mobileWallet.connectAnd(callback);
+
+        expect(callback).toHaveBeenCalledWith(transportWallet);
+        expect(mockAuthorizeSession).not.toHaveBeenCalled();
+        expect(result).toBe('connected-via-callback');
+    });
+
+    it('signs messages with the authorized address', async () => {
+        expect.assertions(3);
+        const signedMessage = Uint8Array.from([9, 9, 9]);
+        const transportWallet = createTransportWallet({
+            signMessages: jest.fn().mockResolvedValue([signedMessage]),
+        });
+        const { mobileWallet } = useMobileWalletTestHarness({ transportWallet });
+
+        const result = await mobileWallet.signMessages(Uint8Array.from([1, 2, 3]));
+
+        expect(mockAuthorizeSession).toHaveBeenCalledWith(transportWallet);
+        expect(transportWallet.signMessages).toHaveBeenCalledWith({
+            addresses: [FIRST_ADDRESS_BASE64],
+            payloads: [Uint8Array.from([1, 2, 3])],
+        });
+        expect(result).toEqual(signedMessage);
+    });
+
+    it('delegates signTransactions and signAndSendTransactions through the transport wallet', async () => {
+        expect.assertions(5);
+        const signedTransaction = {
+            id: 'signed-transaction',
+        };
+        const transaction = {
+            id: 'transaction',
+        };
+        const transportWallet = createTransportWallet({
+            signAndSendTransactions: jest.fn().mockResolvedValue(['signature']),
+            signTransactions: jest.fn().mockResolvedValue([signedTransaction]),
+        });
+        const { mobileWallet } = useMobileWalletTestHarness({ transportWallet });
+
+        const signedResult = await mobileWallet.signTransactions(transaction as never);
+        const submittedResult = await mobileWallet.signAndSendTransactions(transaction as never, 99n);
+
+        expect(mockAuthorizeSession).toHaveBeenCalledWith(transportWallet);
+        expect(transportWallet.signTransactions).toHaveBeenCalledWith({
+            transactions: [transaction],
+        });
+        expect(transportWallet.signAndSendTransactions).toHaveBeenCalledWith({
+            minContextSlot: 99,
+            transactions: [transaction],
+        });
+        expect(signedResult).toEqual(signedTransaction);
+        expect(submittedResult).toBe('signature');
+    });
+
+    it('routes deprecated aliases to the current methods', async () => {
+        expect.assertions(4);
+        const signedMessage = Uint8Array.from([6, 6, 6]);
+        const signedTransaction = {
+            id: 'signed-transaction',
+        };
+        const transportWallet = createTransportWallet({
+            signAndSendTransactions: jest.fn().mockResolvedValue(['signature']),
+            signMessages: jest.fn().mockResolvedValue([signedMessage]),
+            signTransactions: jest.fn().mockResolvedValue([signedTransaction]),
+        });
+        const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+        const { mobileWallet } = useMobileWalletTestHarness({ transportWallet });
+
+        expect(await mobileWallet.signMessage(Uint8Array.from([1, 1, 1]))).toEqual(signedMessage);
+        expect(await mobileWallet.signAndSendTransaction({ id: 'tx' } as never, 10n)).toBe('signature');
+        expect(await mobileWallet.signTransaction({ id: 'tx' } as never)).toEqual(signedTransaction);
+        expect(warnSpy).toHaveBeenCalledTimes(3);
+    });
+
+    it('routes the deprecated sendTransaction alias to sendTransactions', async () => {
+        expect.assertions(2);
+        const { mobileWallet } = useMobileWalletTestHarness();
+        const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+        expect(await mobileWallet.sendTransaction([{ id: 'ix' } as never])).toBe('decoded-signature');
+        expect(warnSpy).toHaveBeenCalledWith(
+            '[wallet-ui] `sendTransaction` is deprecated. Use `sendTransactions` instead.',
+        );
+    });
+
+    it('builds and sends transactions through the kit pipeline helpers', async () => {
+        expect.assertions(7);
+        const blockhash = {
+            blockhash: 'latest-blockhash',
+            lastValidBlockHeight: 123,
+        };
+        const instructions = [{ id: 'instruction' }] as never[];
+        const { mobileWallet } = useMobileWalletTestHarness({
+            contextOverrides: {
+                client: {
+                    rpc: {
+                        getLatestBlockhash: jest.fn(() => ({
+                            send: jest.fn().mockResolvedValue({
+                                context: {
+                                    slot: 42n,
+                                },
+                                value: blockhash,
+                            }),
+                        })),
+                    },
+                    rpcSubscriptions: {},
+                },
+            },
+        });
+
+        const result = await mobileWallet.sendTransactions(instructions);
+
+        expect(mockCreateTransactionMessage).toHaveBeenCalledWith({
+            version: 0,
+        });
+        expect(mockAppendTransactionMessageInstructions).toHaveBeenCalledWith(instructions, {
+            version: 0,
+        });
+        expect(mockSetTransactionMessageFeePayerSigner).toHaveBeenCalledWith(
+            {
+                address: FIRST_ADDRESS,
+                signAndSendTransactions: expect.any(Function),
+            },
+            {
+                instructions,
+                transactionMessage: {
+                    version: 0,
+                },
+            },
+        );
+        expect(mockSetTransactionMessageLifetimeUsingBlockhash).toHaveBeenCalledWith(blockhash, {
+            signer: {
+                address: FIRST_ADDRESS,
+                signAndSendTransactions: expect.any(Function),
+            },
+            transactionMessage: {
+                instructions,
+                transactionMessage: {
+                    version: 0,
+                },
+            },
+        });
+        expect(mockSignAndSendTransactionMessageWithSigners).toHaveBeenCalledWith({
+            blockhash,
+            transactionMessage: {
+                signer: {
+                    address: FIRST_ADDRESS,
+                    signAndSendTransactions: expect.any(Function),
+                },
+                transactionMessage: {
+                    instructions,
+                    transactionMessage: {
+                        version: 0,
+                    },
+                },
+            },
+        });
+        expect(mockDecodeBase58).toHaveBeenCalledWith(Uint8Array.from([7, 8, 9]));
+        expect(result).toBe('decoded-signature');
+    });
+});
+
+function createAuthorizationHookValue() {
+    return {
+        accounts: [createExpectedAccount({ label: 'Primary' })],
+        authorizeSession: mockAuthorizeSession,
+        authorizeSessionWithSignIn: mockAuthorizeSessionWithSignIn,
+        deauthorizeSession: mockDeauthorizeSession,
+        deauthorizeSessions: mockDeauthorizeSessions,
+        selectedAccount: createExpectedAccount({ label: 'Primary' }),
+    };
+}
+
+function createContextValue(overrides: Record<string, unknown> = {}) {
+    return {
+        cache: undefined,
+        chain: 'solana:devnet',
+        client: {
+            rpc: {
+                getLatestBlockhash: jest.fn(() => ({
+                    send: jest.fn().mockResolvedValue({
+                        context: {
+                            slot: 42n,
+                        },
+                        value: {
+                            blockhash: 'latest-blockhash',
+                            lastValidBlockHeight: 123,
+                        },
+                    }),
+                })),
+            },
+            rpcSubscriptions: {},
+        },
+        identity: {
+            name: 'Wallet UI',
+            uri: 'https://wallet-ui.dev',
+        },
+        store: {},
+        ...overrides,
+    };
+}
+
+function createTransportWallet({
+    authorize = jest.fn(),
+    signAndSendTransactions = jest.fn(),
+    signMessages = jest.fn(),
+    signTransactions = jest.fn(),
+}: {
+    authorize?: jest.Mock;
+    signAndSendTransactions?: jest.Mock;
+    signMessages?: jest.Mock;
+    signTransactions?: jest.Mock;
+} = {}) {
+    return {
+        authorize,
+        signAndSendTransactions,
+        signMessages,
+        signTransactions,
+    };
+}
+
+function useMobileWalletTestHarness({
+    contextOverrides,
+    transportWallet = createTransportWallet(),
+}: {
+    contextOverrides?: Record<string, unknown>;
+    transportWallet?: ReturnType<typeof createTransportWallet>;
+} = {}) {
+    currentContext = createContextValue(contextOverrides);
+    resetAsyncStorageMock(AsyncStorage as unknown as Parameters<typeof resetAsyncStorageMock>[0]);
+    mockAppendTransactionMessageInstructions.mockImplementation((instructions, transactionMessage) => ({
+        instructions,
+        transactionMessage,
+    }));
+    mockAuthorizeSession.mockResolvedValue(createExpectedAccount({ label: 'Primary' }));
+    mockAuthorizeSessionWithSignIn.mockResolvedValue({
+        account: createExpectedAccount({ label: 'Primary' }),
+        signature: Uint8Array.from([1, 2, 3]),
+        signedMessage: Uint8Array.from([4, 5, 6]),
+    });
+    mockCreateTransactionMessage.mockReturnValue({
+        version: 0,
+    });
+    mockDecodeBase58.mockReturnValue('decoded-signature');
+    mockDeauthorizeSession.mockResolvedValue(undefined);
+    mockDeauthorizeSessions.mockResolvedValue(undefined);
+    mockPipe.mockImplementation((value, ...steps) => steps.reduce((current, step) => step(current), value));
+    mockSetTransactionMessageFeePayerSigner.mockImplementation((signer, transactionMessage) => ({
+        signer,
+        transactionMessage,
+    }));
+    mockSetTransactionMessageLifetimeUsingBlockhash.mockImplementation((blockhash, transactionMessage) => ({
+        blockhash,
+        transactionMessage,
+    }));
+    mockSignAndSendTransactionMessageWithSigners.mockResolvedValue(Uint8Array.from([7, 8, 9]));
+    mockTransact.mockImplementation(async callback => await callback(transportWallet));
+    mockUseAuthorization.mockReturnValue(createAuthorizationHookValue());
+
+    return {
+        mobileWallet: useMobileWallet(),
+        transportWallet,
+    };
+}

--- a/packages/react-native-kit/src/test-utils/fixtures.ts
+++ b/packages/react-native-kit/src/test-utils/fixtures.ts
@@ -1,0 +1,129 @@
+import {
+    Account as AuthorizedAccount,
+    AuthorizationResult,
+    SignInResult,
+} from '@solana-mobile/mobile-wallet-adapter-protocol';
+
+import type { Cache } from '../cache';
+import type { SignInOutput } from '../convert-sign-in-result';
+import type { Account, WalletAuthorization } from '../use-authorization';
+
+type CacheMocks = Cache<WalletAuthorization | undefined> & {
+    clear: jest.Mock;
+    get: jest.Mock;
+    set: jest.Mock;
+};
+
+export const FIRST_ADDRESS = '11111111111111111111111111111111';
+export const FIRST_ADDRESS_BASE64 = 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=';
+export const ICON = 'data:image/svg+xml;base64,PHN2Zy8+';
+export const SECOND_ADDRESS = 'Stake11111111111111111111111111111111111111';
+export const SECOND_ADDRESS_BASE64 = 'BqHYF5E3VCqYNDe9/ip6slV/U1yKeHIraKSdwAAAAAA=';
+export const SIGNATURE_BASE64 = 'c2lnbmF0dXJl';
+export const SIGNED_MESSAGE_BASE64 = 'c2lnbmVkLW1lc3NhZ2U=';
+
+export function createAuthorizedAccount({
+    address = FIRST_ADDRESS_BASE64,
+    icon,
+    label,
+}: {
+    address?: string;
+    icon?: typeof ICON;
+    label?: string;
+} = {}): AuthorizedAccount {
+    return {
+        address,
+        icon,
+        label,
+    };
+}
+
+export function createAuthorizationResult({
+    accounts = [createAuthorizedAccount()],
+    authToken = 'next-auth-token',
+    signInResult,
+}: {
+    accounts?: AuthorizedAccount[];
+    authToken?: string;
+    signInResult?: SignInResult;
+} = {}): AuthorizationResult {
+    return {
+        accounts,
+        auth_token: authToken,
+        sign_in_result: signInResult,
+        wallet_uri_base: 'https://wallet.example',
+    };
+}
+
+export function createCache({
+    clear = jest.fn().mockResolvedValue(undefined),
+    get = jest.fn().mockResolvedValue(undefined),
+    set = jest.fn().mockResolvedValue(undefined),
+}: {
+    clear?: jest.Mock;
+    get?: jest.Mock;
+    set?: jest.Mock;
+} = {}): CacheMocks {
+    return {
+        clear,
+        get,
+        set,
+    };
+}
+
+export function createExpectedAccount({
+    address = FIRST_ADDRESS,
+    addressBase64 = FIRST_ADDRESS_BASE64,
+    icon,
+    label = '11111111..11111111',
+}: {
+    address?: string;
+    addressBase64?: string;
+    icon?: typeof ICON;
+    label?: string;
+} = {}): Account {
+    return {
+        address: address as Account['address'],
+        addressBase64,
+        icon,
+        label,
+    };
+}
+
+export function createExpectedAuthorization({
+    accounts = [createExpectedAccount()],
+    authToken = 'cached-auth-token',
+    selectedAccount = accounts[0],
+}: {
+    accounts?: Account[];
+    authToken?: string;
+    selectedAccount?: Account;
+} = {}): WalletAuthorization {
+    return {
+        accounts,
+        authToken,
+        selectedAccount,
+    };
+}
+
+export function createExpectedSignInOutput({
+    account = createExpectedAccount(),
+    signInResult = createSignInResult(),
+}: {
+    account?: Account;
+    signInResult?: SignInResult;
+} = {}): SignInOutput {
+    return {
+        account,
+        signature: new TextEncoder().encode(signInResult.signature),
+        signedMessage: new TextEncoder().encode(signInResult.signed_message),
+    };
+}
+
+export function createSignInResult(): SignInResult {
+    return {
+        address: FIRST_ADDRESS_BASE64,
+        signature: SIGNATURE_BASE64,
+        signed_message: SIGNED_MESSAGE_BASE64,
+    };
+}

--- a/packages/react-native-kit/src/test-utils/react-test-renderer.tsx
+++ b/packages/react-native-kit/src/test-utils/react-test-renderer.tsx
@@ -1,0 +1,61 @@
+import React, { type ReactNode } from 'react';
+import { act, create, type ReactTestRenderer } from 'react-test-renderer';
+
+type HookComponentProps<Props, Result> = Readonly<{
+    hook: (props: Props) => Result;
+    hookProps: Props;
+    onRender: (result: Result) => void;
+}>;
+
+type RenderHookOptions<Props> = Readonly<{
+    initialProps: Props;
+    wrapper?: (props: { children: ReactNode }) => ReactNode;
+}>;
+
+export { act };
+
+export function renderHook<Props, Result>(
+    hook: (props: Props) => Result,
+    { initialProps, wrapper: Wrapper }: RenderHookOptions<Props>,
+) {
+    let currentResult!: Result;
+    let renderer!: ReactTestRenderer;
+
+    function HookComponent({ hook: currentHook, hookProps, onRender }: HookComponentProps<Props, Result>) {
+        onRender(currentHook(hookProps));
+        return null;
+    }
+
+    function renderNode(hookProps: Props) {
+        const node = (
+            <HookComponent
+                hook={hook}
+                hookProps={hookProps}
+                onRender={(nextResult: Result) => {
+                    currentResult = nextResult;
+                }}
+            />
+        );
+        return Wrapper ? <Wrapper>{node}</Wrapper> : node;
+    }
+
+    act(() => {
+        renderer = create(renderNode(initialProps));
+    });
+
+    return {
+        rerender(nextProps: Props) {
+            act(() => {
+                renderer.update(renderNode(nextProps));
+            });
+        },
+        get result() {
+            return currentResult;
+        },
+        unmount() {
+            act(() => {
+                renderer.unmount();
+            });
+        },
+    };
+}

--- a/packages/react-native-web3js/src/__tests__/authorization-store-test.ts
+++ b/packages/react-native-web3js/src/__tests__/authorization-store-test.ts
@@ -1,0 +1,48 @@
+import { createAuthorizationStore } from '../authorization-store';
+import { createCache, createExpectedAuthorization } from '../test-utils/fixtures';
+
+describe('authorization-store', () => {
+    it('loads authorization from the cache and exposes computed values', async () => {
+        expect.assertions(4);
+        const authorization = createExpectedAuthorization();
+        const cache = createCache({
+            get: jest.fn().mockResolvedValue(authorization),
+        });
+        const store = createAuthorizationStore({ cache });
+
+        await expect(store.fetch()).resolves.toBe(authorization);
+        expect(store.$accounts.get()).toBe(authorization.accounts);
+        expect(store.$authToken.get()).toBe(authorization.authToken);
+        expect(store.$selectedAccount.get()).toBe(authorization.selectedAccount);
+    });
+
+    it('persists authorization to the cache and exposes computed values', async () => {
+        expect.assertions(5);
+        const authorization = createExpectedAuthorization();
+        const cache = createCache();
+        const store = createAuthorizationStore({ cache });
+
+        await store.persist(authorization);
+
+        expect(cache.set).toHaveBeenCalledWith(authorization);
+        expect(cache.clear).not.toHaveBeenCalled();
+        expect(store.$accounts.get()).toBe(authorization.accounts);
+        expect(store.$authToken.get()).toBe(authorization.authToken);
+        expect(store.$selectedAccount.get()).toBe(authorization.selectedAccount);
+    });
+
+    it('clears authorization from the cache and resets computed values', async () => {
+        expect.assertions(4);
+        const authorization = createExpectedAuthorization();
+        const cache = createCache();
+        const store = createAuthorizationStore({ cache });
+
+        await store.persist(authorization);
+        await store.persist(null);
+
+        expect(cache.clear).toHaveBeenCalledTimes(1);
+        expect(store.$accounts.get()).toBeNull();
+        expect(store.$authToken.get()).toBeUndefined();
+        expect(store.$selectedAccount.get()).toBeUndefined();
+    });
+});

--- a/packages/react-native-web3js/src/__tests__/dummy-test.ts
+++ b/packages/react-native-web3js/src/__tests__/dummy-test.ts
@@ -1,5 +1,0 @@
-describe('dummy', () => {
-    it('should return something', () => {
-        expect(true).toBe(true);
-    });
-});

--- a/packages/react-native-web3js/src/__tests__/helpers-test.ts
+++ b/packages/react-native-web3js/src/__tests__/helpers-test.ts
@@ -1,0 +1,150 @@
+import { Buffer } from 'buffer';
+
+import { convertSignInResult } from '../convert-sign-in-result';
+import { getAccountFromAuthorizedAccount } from '../get-account-from-authorized-account';
+import { getAuthorizationFromAuthorizationResult } from '../get-authorization-from-authorization-result';
+import {
+    createAuthorizationResult,
+    createAuthorizedAccount,
+    createExpectedAccount,
+    createExpectedAuthorization,
+    createExpectedSignInOutput,
+    createSignInResult,
+    FIRST_ADDRESS,
+    FIRST_ADDRESS_BASE64,
+    ICON,
+    SECOND_ADDRESS,
+    SECOND_ADDRESS_BASE64,
+} from '../test-utils/fixtures';
+
+describe('react-native-web3js helpers', () => {
+    beforeEach(() => {
+        setupTestEnvironment();
+    });
+
+    it('converts an authorized account into a wallet-ui account', () => {
+        expect.assertions(1);
+        const authorizedAccount = createAuthorizedAccount({
+            address: FIRST_ADDRESS_BASE64,
+            icon: ICON,
+            label: 'Primary',
+        });
+        const account = getAccountFromAuthorizedAccount(authorizedAccount);
+
+        expect(account).toEqual(
+            createExpectedAccount({
+                address: FIRST_ADDRESS,
+                addressBase64: FIRST_ADDRESS_BASE64,
+                icon: ICON,
+                label: 'Primary',
+            }),
+        );
+    });
+
+    it('falls back to the first account when the previously selected account is no longer authorized', () => {
+        expect.assertions(1);
+        const previousSelection = getAccountFromAuthorizedAccount(
+            createAuthorizedAccount({
+                address: FIRST_ADDRESS_BASE64,
+            }),
+        );
+        const authorization = getAuthorizationFromAuthorizationResult(
+            createAuthorizationResult({
+                accounts: [
+                    createAuthorizedAccount({
+                        address: SECOND_ADDRESS_BASE64,
+                    }),
+                ],
+            }),
+            previousSelection,
+        );
+
+        expect(authorization).toEqual(
+            createExpectedAuthorization({
+                accounts: [
+                    createExpectedAccount({
+                        address: SECOND_ADDRESS,
+                        addressBase64: SECOND_ADDRESS_BASE64,
+                        label: 'Stake111..11111111',
+                    }),
+                ],
+                authToken: 'next-auth-token',
+            }),
+        );
+    });
+
+    it('keeps the previous selection when it is still present in the authorization result', () => {
+        expect.assertions(2);
+        const previousSelection = getAccountFromAuthorizedAccount(
+            createAuthorizedAccount({
+                address: SECOND_ADDRESS_BASE64,
+                label: 'Stake account',
+            }),
+        );
+        const authorization = getAuthorizationFromAuthorizationResult(
+            createAuthorizationResult({
+                accounts: [
+                    createAuthorizedAccount({
+                        address: FIRST_ADDRESS_BASE64,
+                    }),
+                    createAuthorizedAccount({
+                        address: SECOND_ADDRESS_BASE64,
+                        label: 'Stake account',
+                    }),
+                ],
+            }),
+            previousSelection,
+        );
+
+        expect(authorization.selectedAccount).toBe(previousSelection);
+        expect(authorization.accounts).toEqual([
+            createExpectedAccount({
+                address: FIRST_ADDRESS,
+                addressBase64: FIRST_ADDRESS_BASE64,
+                label: '11111111..11111111',
+            }),
+            createExpectedAccount({
+                address: SECOND_ADDRESS,
+                addressBase64: SECOND_ADDRESS_BASE64,
+                label: 'Stake account',
+            }),
+        ]);
+    });
+
+    it('normalizes the sign-in result into Uint8Array payloads', () => {
+        expect.assertions(1);
+        const account = getAccountFromAuthorizedAccount(
+            createAuthorizedAccount({
+                address: FIRST_ADDRESS_BASE64,
+                label: 'Primary',
+            }),
+        );
+        const signInResult = createSignInResult();
+
+        expect(convertSignInResult({ account, signInResult })).toEqual(
+            createExpectedSignInOutput({
+                account: createExpectedAccount({
+                    address: FIRST_ADDRESS,
+                    addressBase64: FIRST_ADDRESS_BASE64,
+                    label: 'Primary',
+                }),
+                signInResult,
+            }),
+        );
+    });
+
+    it('keeps the deprecated publicKey alias aligned with address', () => {
+        expect.assertions(1);
+        const account = getAccountFromAuthorizedAccount(
+            createAuthorizedAccount({
+                address: FIRST_ADDRESS_BASE64,
+            }),
+        );
+
+        expect(account.publicKey.equals(account.address)).toBe(true);
+    });
+});
+
+function setupTestEnvironment() {
+    globalThis.Buffer = Buffer;
+}

--- a/packages/react-native-web3js/src/__tests__/index-test.ts
+++ b/packages/react-native-web3js/src/__tests__/index-test.ts
@@ -1,0 +1,28 @@
+import { createAuthorizationStore } from '../authorization-store';
+import { convertSignInResult } from '../convert-sign-in-result';
+import * as reactNativeWeb3js from '../index';
+import { MobileWalletProvider, MobileWalletProviderContext } from '../mobile-wallet-provider';
+import { useAuthorization } from '../use-authorization';
+import { useMobileWallet } from '../use-mobile-wallet';
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+    __esModule: true,
+    default: {
+        getItem: jest.fn(),
+        removeItem: jest.fn(),
+        setItem: jest.fn(),
+    },
+}));
+
+describe('index', () => {
+    it('re-exports the local runtime surface from the barrel', () => {
+        expect.assertions(6);
+
+        expect(reactNativeWeb3js.MobileWalletProvider).toBe(MobileWalletProvider);
+        expect(reactNativeWeb3js.MobileWalletProviderContext).toBe(MobileWalletProviderContext);
+        expect(reactNativeWeb3js.convertSignInResult).toBe(convertSignInResult);
+        expect(reactNativeWeb3js.createAuthorizationStore).toBe(createAuthorizationStore);
+        expect(reactNativeWeb3js.useAuthorization).toBe(useAuthorization);
+        expect(reactNativeWeb3js.useMobileWallet).toBe(useMobileWallet);
+    });
+});

--- a/packages/react-native-web3js/src/__tests__/mobile-wallet-provider-test.tsx
+++ b/packages/react-native-web3js/src/__tests__/mobile-wallet-provider-test.tsx
@@ -1,0 +1,92 @@
+import { Connection } from '@solana/web3.js';
+import { AppIdentity, Chain } from '@solana-mobile/mobile-wallet-adapter-protocol';
+import React, { type ReactNode, useContext } from 'react';
+
+import { act, renderHook } from '../test-utils/react-test-renderer';
+import { createAsyncStorageCache } from '../async-storage-cache';
+import type { Cache } from '../cache';
+import { MobileWalletProvider, MobileWalletProviderContext } from '../mobile-wallet-provider';
+import { createCache } from '../test-utils/fixtures';
+import type { WalletAuthorization } from '../use-authorization';
+
+jest.mock('../async-storage-cache', () => ({
+    createAsyncStorageCache: jest.fn(),
+}));
+
+const mockCreateAsyncStorageCache = jest.mocked(createAsyncStorageCache);
+const CHAIN = 'solana:devnet' as Chain;
+const ENDPOINT = 'https://rpc.wallet-ui.dev';
+const IDENTITY = {
+    name: 'Wallet UI',
+    uri: 'https://wallet-ui.dev',
+} as AppIdentity;
+
+describe('MobileWalletProvider', () => {
+    beforeEach(() => {
+        mockCreateAsyncStorageCache.mockReset();
+    });
+
+    it('uses the provided cache and fetches authorization on mount', async () => {
+        expect.assertions(7);
+        const cache = createCache();
+        const hook = renderHook(useProviderState, {
+            initialProps: undefined,
+            wrapper: createProviderWrapper({
+                cache,
+            }),
+        });
+
+        await act(async () => {
+            await Promise.resolve();
+        });
+
+        expect(cache.get).toHaveBeenCalledTimes(1);
+        expect(hook.result.cache).toBe(cache);
+        expect(hook.result.chain).toBe(CHAIN);
+        expect(hook.result.connection).toBeInstanceOf(Connection);
+        expect(hook.result.connection.rpcEndpoint).toBe(ENDPOINT);
+        expect(hook.result.identity).toBe(IDENTITY);
+        expect(hook.result.store).toEqual(expect.objectContaining({ fetch: expect.any(Function), persist: expect.any(Function) }));
+    });
+
+    it('creates a default cache when one is not provided', async () => {
+        expect.assertions(6);
+        const cache = createCache();
+
+        mockCreateAsyncStorageCache.mockReturnValue(cache as never);
+
+        const hook = renderHook(useProviderState, {
+            initialProps: undefined,
+            wrapper: createProviderWrapper({}),
+        });
+
+        await act(async () => {
+            await Promise.resolve();
+        });
+
+        expect(mockCreateAsyncStorageCache).toHaveBeenCalledTimes(1);
+        expect(cache.get).toHaveBeenCalledTimes(1);
+        expect(hook.result.cache).toBe(cache);
+        expect(hook.result.chain).toBe(CHAIN);
+        expect(hook.result.connection.rpcEndpoint).toBe(ENDPOINT);
+        expect(hook.result.identity).toBe(IDENTITY);
+    });
+});
+
+function createProviderWrapper({
+    cache,
+}: {
+    cache?: Cache<WalletAuthorization | undefined>;
+}) {
+    return function ProviderWrapper({ children }: { children: unknown }) {
+        return (
+            <MobileWalletProvider cache={cache} chain={CHAIN} endpoint={ENDPOINT} identity={IDENTITY}>
+                {children as ReactNode}
+            </MobileWalletProvider>
+        );
+    };
+}
+
+function useProviderState(_: undefined) {
+    return useContext(MobileWalletProviderContext);
+}

--- a/packages/react-native-web3js/src/__tests__/use-authorization-store-test.tsx
+++ b/packages/react-native-web3js/src/__tests__/use-authorization-store-test.tsx
@@ -1,0 +1,37 @@
+import { act, renderHook } from '../test-utils/react-test-renderer';
+import { createAuthorizationStore } from '../authorization-store';
+import { createCache, createExpectedAuthorization } from '../test-utils/fixtures';
+import { useAuthorizationStore } from '../use-authorization-store';
+
+describe('useAuthorizationStore', () => {
+    it('returns the empty authorization state before any authorization is loaded', () => {
+        expect.assertions(4);
+        const store = createAuthorizationStore({ cache: createCache() });
+        const hook = renderHook(useAuthorizationStore, {
+            initialProps: { store },
+        });
+
+        expect(hook.result.accounts).toBeNull();
+        expect(hook.result.authToken).toBeUndefined();
+        expect(hook.result.persist).toBe(store.persist);
+        expect(hook.result.selectedAccount).toBeUndefined();
+    });
+
+    it('updates when the authorization store changes', async () => {
+        expect.assertions(4);
+        const authorization = createExpectedAuthorization();
+        const store = createAuthorizationStore({ cache: createCache() });
+        const hook = renderHook(useAuthorizationStore, {
+            initialProps: { store },
+        });
+
+        await act(async () => {
+            await store.persist(authorization);
+        });
+
+        expect(hook.result.accounts).toBe(authorization.accounts);
+        expect(hook.result.authToken).toBe(authorization.authToken);
+        expect(hook.result.persist).toBe(store.persist);
+        expect(hook.result.selectedAccount).toBe(authorization.selectedAccount);
+    });
+});

--- a/packages/react-native-web3js/src/__tests__/use-authorization-test.tsx
+++ b/packages/react-native-web3js/src/__tests__/use-authorization-test.tsx
@@ -1,0 +1,252 @@
+import {
+    AppIdentity,
+    AuthorizeAPI,
+    Chain,
+    DeauthorizeAPI,
+    SignInPayload,
+    SolanaMobileWalletAdapterProtocolError,
+    SolanaMobileWalletAdapterProtocolErrorCode,
+} from '@solana-mobile/mobile-wallet-adapter-protocol';
+import { Buffer } from 'buffer';
+
+import {
+    createAuthorizedAccount,
+    createAuthorizationResult,
+    createExpectedAccount,
+    createExpectedAuthorization,
+    createExpectedSignInOutput,
+    createSignInResult,
+    FIRST_ADDRESS,
+    SECOND_ADDRESS,
+    SECOND_ADDRESS_BASE64,
+} from '../test-utils/fixtures';
+import type { WalletAuthorization } from '../use-authorization';
+import { useAuthorization } from '../use-authorization';
+
+const mockUseAuthorizationStore = jest.fn();
+
+jest.mock('react', () => {
+    const actual = jest.requireActual('react');
+
+    return {
+        ...actual,
+        useCallback: (callback: unknown) => callback,
+        useMemo: (factory: () => unknown) => factory(),
+    };
+});
+
+jest.mock('../use-authorization-store', () => ({
+    useAuthorizationStore: (...args: unknown[]) => mockUseAuthorizationStore(...args),
+}));
+
+const CHAIN = 'solana:devnet' as Chain;
+const IDENTITY = {
+    name: 'Wallet UI',
+    uri: 'https://wallet-ui.dev',
+} as AppIdentity;
+
+describe('useAuthorization', () => {
+    beforeEach(() => {
+        setupTestEnvironment();
+    });
+
+    it('authorizes with the existing auth token and persists the selected authorization', async () => {
+        expect.assertions(3);
+        const { authorization, persist } = useAuthorizationTestHarness();
+        const wallet = createWallet({
+            authorize: jest.fn().mockResolvedValue(
+                createAuthorizationResult({
+                    accounts: [
+                        createAuthorizedAccount({
+                            address: SECOND_ADDRESS_BASE64,
+                            label: 'Stake account',
+                        }),
+                    ],
+                    authToken: 'next-auth-token',
+                }),
+            ),
+        });
+
+        const selectedAccount = await authorization.authorizeSession(wallet as AuthorizeAPI);
+
+        expect(wallet.authorize).toHaveBeenCalledWith({
+            auth_token: 'cached-auth-token',
+            chain: CHAIN,
+            identity: IDENTITY,
+        });
+        expect(lastPersistedAuthorization(persist)).toEqual(
+            createExpectedAuthorization({
+                accounts: [
+                    createExpectedAccount({
+                        address: SECOND_ADDRESS,
+                        addressBase64: SECOND_ADDRESS_BASE64,
+                        label: 'Stake account',
+                    }),
+                ],
+                authToken: 'next-auth-token',
+            }),
+        );
+        expect(selectedAccount).toEqual(
+            createExpectedAccount({
+                address: SECOND_ADDRESS,
+                addressBase64: SECOND_ADDRESS_BASE64,
+                label: 'Stake account',
+            }),
+        );
+    });
+
+    it('retries without the cached auth token when authorization fails', async () => {
+        expect.assertions(2);
+        const { authorization, persist } = useAuthorizationTestHarness();
+        const wallet = createWallet({
+            authorize: jest
+                .fn()
+                .mockRejectedValueOnce(
+                    new SolanaMobileWalletAdapterProtocolError(
+                        1,
+                        SolanaMobileWalletAdapterProtocolErrorCode.ERROR_AUTHORIZATION_FAILED,
+                        'Authorization failed',
+                    ),
+                )
+                .mockResolvedValueOnce(
+                    createAuthorizationResult({
+                        accounts: [
+                            createAuthorizedAccount({
+                                address: SECOND_ADDRESS_BASE64,
+                            }),
+                        ],
+                        authToken: 'retried-auth-token',
+                    }),
+                ),
+        });
+
+        await authorization.authorizeSession(wallet as AuthorizeAPI);
+
+        expect(wallet.authorize.mock.calls).toEqual([
+            [
+                {
+                    auth_token: 'cached-auth-token',
+                    chain: CHAIN,
+                    identity: IDENTITY,
+                },
+            ],
+            [
+                {
+                    chain: CHAIN,
+                    identity: IDENTITY,
+                },
+            ],
+        ]);
+        expect(lastPersistedAuthorization(persist)).toEqual(
+            createExpectedAuthorization({
+                accounts: [
+                    createExpectedAccount({
+                        address: SECOND_ADDRESS,
+                        addressBase64: SECOND_ADDRESS_BASE64,
+                        label: 'Stake111..11111111',
+                    }),
+                ],
+                authToken: 'retried-auth-token',
+            }),
+        );
+    });
+
+    it('returns a normalized sign-in result and persists the next authorization', async () => {
+        expect.assertions(3);
+        const { authorization, persist } = useAuthorizationTestHarness();
+        const signInPayload = {
+            address: FIRST_ADDRESS,
+            domain: 'wallet-ui.dev',
+        } as SignInPayload;
+        const signInResult = createSignInResult();
+        const wallet = createWallet({
+            authorize: jest.fn().mockResolvedValue(
+                createAuthorizationResult({
+                    authToken: 'signed-in-auth-token',
+                    signInResult,
+                }),
+            ),
+        });
+
+        const output = await authorization.authorizeSessionWithSignIn(wallet as AuthorizeAPI, signInPayload);
+
+        expect(wallet.authorize).toHaveBeenCalledWith({
+            auth_token: 'cached-auth-token',
+            chain: CHAIN,
+            identity: IDENTITY,
+            sign_in_payload: signInPayload,
+        });
+        expect(lastPersistedAuthorization(persist)).toEqual(
+            createExpectedAuthorization({
+                authToken: 'signed-in-auth-token',
+            }),
+        );
+        expect(output).toEqual(
+            createExpectedSignInOutput({
+                account: createExpectedAccount(),
+                signInResult,
+            }),
+        );
+    });
+
+    it('deauthorizes the current session and clears persisted state', async () => {
+        expect.assertions(2);
+        const { authorization, persist } = useAuthorizationTestHarness();
+        const wallet = createWallet({
+            deauthorize: jest.fn().mockResolvedValue(undefined),
+        });
+
+        await authorization.deauthorizeSession(wallet as DeauthorizeAPI);
+
+        expect(wallet.deauthorize).toHaveBeenCalledWith({
+            auth_token: 'cached-auth-token',
+        });
+        expect(persist).toHaveBeenCalledWith(null);
+    });
+
+    it('clears persisted state without a wallet round-trip when deauthorizing all sessions', async () => {
+        expect.assertions(1);
+        const { authorization, persist } = useAuthorizationTestHarness();
+
+        await authorization.deauthorizeSessions();
+
+        expect(persist).toHaveBeenCalledWith(null);
+    });
+});
+
+function createWallet({
+    authorize = jest.fn(),
+    deauthorize = jest.fn(),
+}: {
+    authorize?: jest.Mock;
+    deauthorize?: jest.Mock;
+} = {}) {
+    return {
+        authorize,
+        deauthorize,
+    };
+}
+
+function lastPersistedAuthorization(persist: jest.Mock): WalletAuthorization {
+    return persist.mock.calls.at(-1)?.[0] as WalletAuthorization;
+}
+
+function useAuthorizationTestHarness() {
+    const persist = jest.fn().mockResolvedValue(undefined);
+
+    mockUseAuthorizationStore.mockReturnValue({
+        accounts: [createExpectedAccount()],
+        authToken: 'cached-auth-token',
+        persist,
+        selectedAccount: createExpectedAccount(),
+    });
+
+    return {
+        authorization: useAuthorization({ chain: CHAIN, identity: IDENTITY, store: {} as never }),
+        persist,
+    };
+}
+
+function setupTestEnvironment() {
+    globalThis.Buffer = Buffer;
+}

--- a/packages/react-native-web3js/src/__tests__/use-mobile-wallet-test.tsx
+++ b/packages/react-native-web3js/src/__tests__/use-mobile-wallet-test.tsx
@@ -1,0 +1,213 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { Buffer } from 'buffer';
+
+import { resetAsyncStorageMock } from '../../../test-config/react-native-unit-test-utils';
+import { createExpectedAccount, FIRST_ADDRESS_BASE64 } from '../test-utils/fixtures';
+import { useMobileWallet } from '../use-mobile-wallet';
+
+let currentContext: unknown;
+
+const mockAuthorizeSession = jest.fn();
+const mockAuthorizeSessionWithSignIn = jest.fn();
+const mockDeauthorizeSession = jest.fn();
+const mockDeauthorizeSessions = jest.fn();
+const mockTransact = jest.fn();
+const mockUseAuthorization = jest.fn();
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+    __esModule: true,
+    default: {
+        getItem: jest.fn(),
+        removeItem: jest.fn(),
+        setItem: jest.fn(),
+    },
+}));
+
+jest.mock('react', () => {
+    const actual = jest.requireActual('react');
+
+    return {
+        ...actual,
+        useCallback: (callback: unknown) => callback,
+        useContext: () => currentContext,
+        useMemo: (factory: () => unknown) => factory(),
+    };
+});
+
+jest.mock('@solana-mobile/mobile-wallet-adapter-protocol-web3js', () => ({
+    transact: (...args: unknown[]) => mockTransact(...args),
+}));
+
+jest.mock('../use-authorization', () => ({
+    useAuthorization: (...args: unknown[]) => mockUseAuthorization(...args),
+}));
+
+describe('useMobileWallet', () => {
+    beforeEach(() => {
+        setupTestEnvironment();
+    });
+
+    it('connects through the transport and returns the selected account', async () => {
+        expect.assertions(3);
+        const { mobileWallet } = useMobileWalletTestHarness();
+        const account = await mobileWallet.connect();
+
+        expect(mockTransact).toHaveBeenCalledTimes(1);
+        expect(mockAuthorizeSession).toHaveBeenCalledWith(expect.objectContaining({ authorize: expect.any(Function) }));
+        expect(account).toEqual(createExpectedAccount({ label: 'Primary' }));
+    });
+
+    it('passes the transport wallet into connectAnd callbacks', async () => {
+        expect.assertions(3);
+        const callback = jest.fn().mockResolvedValue('connected-via-callback');
+        const transportWallet = createTransportWallet();
+        const { mobileWallet } = useMobileWalletTestHarness({ transportWallet });
+
+        const result = await mobileWallet.connectAnd(callback);
+
+        expect(callback).toHaveBeenCalledWith(transportWallet);
+        expect(mockAuthorizeSession).not.toHaveBeenCalled();
+        expect(result).toBe('connected-via-callback');
+    });
+
+    it('signs messages with the authorized address', async () => {
+        expect.assertions(3);
+        const signedMessage = Uint8Array.from([9, 9, 9]);
+        const transportWallet = createTransportWallet({
+            signMessages: jest.fn().mockResolvedValue([signedMessage]),
+        });
+        const { mobileWallet } = useMobileWalletTestHarness({ transportWallet });
+
+        const result = await mobileWallet.signMessages(Uint8Array.from([1, 2, 3]));
+
+        expect(mockAuthorizeSession).toHaveBeenCalledWith(transportWallet);
+        expect(transportWallet.signMessages).toHaveBeenCalledWith({
+            addresses: [FIRST_ADDRESS_BASE64],
+            payloads: [Uint8Array.from([1, 2, 3])],
+        });
+        expect(result).toEqual(signedMessage);
+    });
+
+    it('delegates signTransactions and signAndSendTransactions through the transport wallet', async () => {
+        expect.assertions(5);
+        const signedTransaction = {
+            id: 'signed-transaction',
+        };
+        const transaction = {
+            id: 'transaction',
+        };
+        const transportWallet = createTransportWallet({
+            signAndSendTransactions: jest.fn().mockResolvedValue(['signature']),
+            signTransactions: jest.fn().mockResolvedValue([signedTransaction]),
+        });
+        const { mobileWallet } = useMobileWalletTestHarness({ transportWallet });
+
+        const signedResult = await mobileWallet.signTransactions(transaction as never);
+        const submittedResult = await mobileWallet.signAndSendTransactions(transaction as never, 99);
+
+        expect(mockAuthorizeSession).toHaveBeenCalledWith(transportWallet);
+        expect(transportWallet.signTransactions).toHaveBeenCalledWith({
+            transactions: [transaction],
+        });
+        expect(transportWallet.signAndSendTransactions).toHaveBeenCalledWith({
+            minContextSlot: 99,
+            transactions: [transaction],
+        });
+        expect(signedResult).toEqual(signedTransaction);
+        expect(submittedResult).toBe('signature');
+    });
+
+    it('routes deprecated aliases to the current methods', async () => {
+        expect.assertions(4);
+        const signedMessage = Uint8Array.from([6, 6, 6]);
+        const signedTransaction = {
+            id: 'signed-transaction',
+        };
+        const transportWallet = createTransportWallet({
+            signAndSendTransactions: jest.fn().mockResolvedValue(['signature']),
+            signMessages: jest.fn().mockResolvedValue([signedMessage]),
+            signTransactions: jest.fn().mockResolvedValue([signedTransaction]),
+        });
+        const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+        const { mobileWallet } = useMobileWalletTestHarness({ transportWallet });
+
+        expect(await mobileWallet.signMessage(Uint8Array.from([1, 1, 1]))).toEqual(signedMessage);
+        expect(await mobileWallet.signAndSendTransaction({ id: 'tx' } as never, 10)).toBe('signature');
+        expect(await mobileWallet.signTransaction({ id: 'tx' } as never)).toEqual(signedTransaction);
+        expect(warnSpy).toHaveBeenCalledTimes(3);
+    });
+});
+
+function createAuthorizationHookValue() {
+    return {
+        accounts: [createExpectedAccount({ label: 'Primary' })],
+        authorizeSession: mockAuthorizeSession,
+        authorizeSessionWithSignIn: mockAuthorizeSessionWithSignIn,
+        deauthorizeSession: mockDeauthorizeSession,
+        deauthorizeSessions: mockDeauthorizeSessions,
+        selectedAccount: createExpectedAccount({ label: 'Primary' }),
+    };
+}
+
+function createContextValue(overrides: Record<string, unknown> = {}) {
+    return {
+        cache: undefined,
+        chain: 'solana:devnet',
+        connection: {},
+        identity: {
+            name: 'Wallet UI',
+            uri: 'https://wallet-ui.dev',
+        },
+        store: {},
+        ...overrides,
+    };
+}
+
+function createTransportWallet({
+    authorize = jest.fn(),
+    signAndSendTransactions = jest.fn(),
+    signMessages = jest.fn(),
+    signTransactions = jest.fn(),
+}: {
+    authorize?: jest.Mock;
+    signAndSendTransactions?: jest.Mock;
+    signMessages?: jest.Mock;
+    signTransactions?: jest.Mock;
+} = {}) {
+    return {
+        authorize,
+        signAndSendTransactions,
+        signMessages,
+        signTransactions,
+    };
+}
+
+function useMobileWalletTestHarness({
+    contextOverrides,
+    transportWallet = createTransportWallet(),
+}: {
+    contextOverrides?: Record<string, unknown>;
+    transportWallet?: ReturnType<typeof createTransportWallet>;
+} = {}) {
+    currentContext = createContextValue(contextOverrides);
+    resetAsyncStorageMock(AsyncStorage as unknown as Parameters<typeof resetAsyncStorageMock>[0]);
+    mockAuthorizeSession.mockResolvedValue(createExpectedAccount({ label: 'Primary' }));
+    mockAuthorizeSessionWithSignIn.mockResolvedValue({
+        account: createExpectedAccount({ label: 'Primary' }),
+        signature: Uint8Array.from([1, 2, 3]),
+        signedMessage: Uint8Array.from([4, 5, 6]),
+    });
+    mockDeauthorizeSession.mockResolvedValue(undefined);
+    mockDeauthorizeSessions.mockResolvedValue(undefined);
+    mockTransact.mockImplementation(async callback => await callback(transportWallet));
+    mockUseAuthorization.mockReturnValue(createAuthorizationHookValue());
+
+    return {
+        mobileWallet: useMobileWallet(),
+        transportWallet,
+    };
+}
+
+function setupTestEnvironment() {
+    globalThis.Buffer = Buffer;
+}

--- a/packages/react-native-web3js/src/test-utils/fixtures.ts
+++ b/packages/react-native-web3js/src/test-utils/fixtures.ts
@@ -1,0 +1,133 @@
+import { PublicKey } from '@solana/web3.js';
+import {
+    Account as AuthorizedAccount,
+    AuthorizationResult,
+    SignInResult,
+} from '@solana-mobile/mobile-wallet-adapter-protocol';
+
+import type { Cache } from '../cache';
+import type { SignInOutput } from '../convert-sign-in-result';
+import type { Account, WalletAuthorization } from '../use-authorization';
+
+type CacheMocks = Cache<WalletAuthorization | undefined> & {
+    clear: jest.Mock;
+    get: jest.Mock;
+    set: jest.Mock;
+};
+
+export const FIRST_ADDRESS = '11111111111111111111111111111111';
+export const FIRST_ADDRESS_BASE64 = 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=';
+export const ICON = 'data:image/svg+xml;base64,PHN2Zy8+';
+export const SECOND_ADDRESS = 'Stake11111111111111111111111111111111111111';
+export const SECOND_ADDRESS_BASE64 = 'BqHYF5E3VCqYNDe9/ip6slV/U1yKeHIraKSdwAAAAAA=';
+export const SIGNATURE_BASE64 = 'c2lnbmF0dXJl';
+export const SIGNED_MESSAGE_BASE64 = 'c2lnbmVkLW1lc3NhZ2U=';
+
+export function createAuthorizedAccount({
+    address = FIRST_ADDRESS_BASE64,
+    icon,
+    label,
+}: {
+    address?: string;
+    icon?: typeof ICON;
+    label?: string;
+} = {}): AuthorizedAccount {
+    return {
+        address,
+        icon,
+        label,
+    };
+}
+
+export function createAuthorizationResult({
+    accounts = [createAuthorizedAccount()],
+    authToken = 'next-auth-token',
+    signInResult,
+}: {
+    accounts?: AuthorizedAccount[];
+    authToken?: string;
+    signInResult?: SignInResult;
+} = {}): AuthorizationResult {
+    return {
+        accounts,
+        auth_token: authToken,
+        sign_in_result: signInResult,
+        wallet_uri_base: 'https://wallet.example',
+    };
+}
+
+export function createCache({
+    clear = jest.fn().mockResolvedValue(undefined),
+    get = jest.fn().mockResolvedValue(undefined),
+    set = jest.fn().mockResolvedValue(undefined),
+}: {
+    clear?: jest.Mock;
+    get?: jest.Mock;
+    set?: jest.Mock;
+} = {}): CacheMocks {
+    return {
+        clear,
+        get,
+        set,
+    };
+}
+
+export function createExpectedAccount({
+    address = FIRST_ADDRESS,
+    addressBase64 = FIRST_ADDRESS_BASE64,
+    icon,
+    label = '11111111..11111111',
+}: {
+    address?: string;
+    addressBase64?: string;
+    icon?: typeof ICON;
+    label?: string;
+} = {}): Account {
+    const publicKey = new PublicKey(address);
+
+    return {
+        address: publicKey,
+        addressBase64,
+        icon,
+        label,
+        publicKey,
+    };
+}
+
+export function createExpectedAuthorization({
+    accounts = [createExpectedAccount()],
+    authToken = 'cached-auth-token',
+    selectedAccount = accounts[0],
+}: {
+    accounts?: Account[];
+    authToken?: string;
+    selectedAccount?: Account;
+} = {}): WalletAuthorization {
+    return {
+        accounts,
+        authToken,
+        selectedAccount,
+    };
+}
+
+export function createExpectedSignInOutput({
+    account = createExpectedAccount(),
+    signInResult = createSignInResult(),
+}: {
+    account?: Account;
+    signInResult?: SignInResult;
+} = {}): SignInOutput {
+    return {
+        account,
+        signature: new TextEncoder().encode(signInResult.signature),
+        signedMessage: new TextEncoder().encode(signInResult.signed_message),
+    };
+}
+
+export function createSignInResult(): SignInResult {
+    return {
+        address: FIRST_ADDRESS_BASE64,
+        signature: SIGNATURE_BASE64,
+        signed_message: SIGNED_MESSAGE_BASE64,
+    };
+}

--- a/packages/react-native-web3js/src/test-utils/react-test-renderer.tsx
+++ b/packages/react-native-web3js/src/test-utils/react-test-renderer.tsx
@@ -1,0 +1,61 @@
+import React, { type ReactNode } from 'react';
+import { act, create, type ReactTestRenderer } from 'react-test-renderer';
+
+type HookComponentProps<Props, Result> = Readonly<{
+    hook: (props: Props) => Result;
+    hookProps: Props;
+    onRender: (result: Result) => void;
+}>;
+
+type RenderHookOptions<Props> = Readonly<{
+    initialProps: Props;
+    wrapper?: (props: { children: ReactNode }) => ReactNode;
+}>;
+
+export { act };
+
+export function renderHook<Props, Result>(
+    hook: (props: Props) => Result,
+    { initialProps, wrapper: Wrapper }: RenderHookOptions<Props>,
+) {
+    let currentResult!: Result;
+    let renderer!: ReactTestRenderer;
+
+    function HookComponent({ hook: currentHook, hookProps, onRender }: HookComponentProps<Props, Result>) {
+        onRender(currentHook(hookProps));
+        return null;
+    }
+
+    function renderNode(hookProps: Props) {
+        const node = (
+            <HookComponent
+                hook={hook}
+                hookProps={hookProps}
+                onRender={(nextResult: Result) => {
+                    currentResult = nextResult;
+                }}
+            />
+        );
+        return Wrapper ? <Wrapper>{node}</Wrapper> : node;
+    }
+
+    act(() => {
+        renderer = create(renderNode(initialProps));
+    });
+
+    return {
+        rerender(nextProps: Props) {
+            act(() => {
+                renderer.update(renderNode(nextProps));
+            });
+        },
+        get result() {
+            return currentResult;
+        },
+        unmount() {
+            act(() => {
+                renderer.unmount();
+            });
+        },
+    };
+}

--- a/packages/test-config/jest-unit.config.common.js
+++ b/packages/test-config/jest-unit.config.common.js
@@ -23,7 +23,7 @@ const config = {
             },
         ],
     },
-    transformIgnorePatterns: ['/node_modules/(?!.*\\@noble/ed25519/)', '\\.pnp\\.[^\\/]+$'],
+    transformIgnorePatterns: ['/node_modules/(?!.*(?:\\@noble/ed25519|\\@nanostores|nanostores|uuid)/)', '\\.pnp\\.[^\\/]+$'],
 };
 
 export default config;

--- a/packages/test-config/react-native-unit-test-utils.tsx
+++ b/packages/test-config/react-native-unit-test-utils.tsx
@@ -1,0 +1,11 @@
+type AsyncStorageModule = {
+    getItem: jest.Mock<Promise<string | null>, [string]>;
+    removeItem: jest.Mock<Promise<void>, [string]>;
+    setItem: jest.Mock<Promise<void>, [string, string]>;
+};
+
+export function resetAsyncStorageMock(asyncStorage: AsyncStorageModule) {
+    asyncStorage.getItem.mockReset().mockResolvedValue(null);
+    asyncStorage.removeItem.mockReset().mockResolvedValue(undefined);
+    asyncStorage.setItem.mockReset().mockResolvedValue(undefined);
+}


### PR DESCRIPTION
Add unit tests for react-native-kit and react-native-web3js across the authorization, wallet, provider, store, and barrel surfaces.

Document the RN testing conventions and add the shared test utilities and Jest transform support needed for the new suites.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wallet-ui/wallet-ui/pull/476" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive Jest/React unit tests across React Native packages covering stores, helpers, provider, hooks, and mobile-wallet flows; removed placeholder dummy tests.

* **Documentation**
  * Added a "Testing Guidance" section with Jest and package-level testing conventions for React Native packages.

* **Chores**
  * Added shared test utilities and fixtures (hook renderer, AsyncStorage reset, fixtures) and updated Jest transform-ignore settings for test runtime.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->