### PR TITLE
fix: use stable Agave v3.1 validator in CI

### DIFF
--- a/scripts/get-latest-validator-release-version.sh
+++ b/scripts/get-latest-validator-release-version.sh
@@ -2,7 +2,7 @@
 (
     set -e
     version=$(node -e \
-      'fetch("https://api.github.com/repos/anza-xyz/agave/releases").then(res => res.json().then(rs => rs.filter(r => !r.prerelease && r.tag_name.startsWith("v2.3."))).then(x => console.log(x[0].tag_name)));'
+      'fetch("https://api.github.com/repos/anza-xyz/agave/releases?per_page=100").then(res => res.json().then(rs => rs.filter(r => !r.prerelease && r.tag_name.startsWith("v3.1."))).then(x => console.log(x[0].tag_name)));'
     )
     if [ -z $version ]; then
       exit 3

--- a/scripts/start-shared-test-validator.sh
+++ b/scripts/start-shared-test-validator.sh
@@ -24,7 +24,7 @@ mkdir -p $LOCK_DIR
   flock -s 200 || exit 1
   (
     if flock -nx 200; then
-      $TEST_VALIDATOR --ledger $TEST_VALIDATOR_LEDGER --reset --quiet --account-dir $FIXTURE_ACCOUNTS_DIR --rpc-pubsub-enable-vote-subscription --rpc-pubsub-enable-block-subscription >/dev/null &
+      $TEST_VALIDATOR --ledger $TEST_VALIDATOR_LEDGER --reset --quiet --account-dir $FIXTURE_ACCOUNTS_DIR --rpc-pubsub-enable-vote-subscription >/dev/null &
       validator_pid=$!
       echo "Started test validator (PID $validator_pid)"
       wait


### PR DESCRIPTION
Request more GitHub release results and switch the validator lookup to the stable v3.1.x line so the installer URL resolves again.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wallet-ui/wallet-ui/pull/477" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release version queries to support v3.1 release pagination
  * Adjusted test validator startup configuration by removing a PubSub subscription flag

<!-- end of auto-generated comment: release notes by coderabbit.ai -->