### PR TITLE
test(examples): add Expo integration tests

### DIFF
--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -50,6 +50,16 @@ jobs:
       - name: Build & Test
         run: pnpm build # Don't add --concurrency here; it's already baked in
 
+      - name: Test Expo Examples
+        run: |
+          pnpm --dir examples/expo-kit test
+          pnpm --dir examples/expo-web3js test
+
+      - name: Lint Expo Examples
+        run: |
+          pnpm --dir examples/expo-kit lint
+          pnpm --dir examples/expo-web3js lint
+
       - name: Stop Test Validator
         if: always() && steps.start-test-validator.outcome == 'success'
         run: kill ${{ steps.start-test-validator.outputs.pid }}

--- a/examples/expo-kit/jest.config.js
+++ b/examples/expo-kit/jest.config.js
@@ -1,0 +1,48 @@
+/* global __dirname */
+
+const path = require('path');
+
+module.exports = {
+    clearMocks: true,
+    moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json'],
+    moduleNameMapper: {
+        '^@/(.*)$': '<rootDir>/$1',
+        '^@react-native-async-storage/async-storage$': '<rootDir>/test/mocks/async-storage.js',
+        '^@solana/kit$': require.resolve('@solana/kit'),
+        '^@wallet-ui/core$': path.resolve(__dirname, '../../packages/core/dist/index.node.cjs'),
+        '^@wallet-ui/react-native-kit$': path.resolve(__dirname, '../../packages/react-native-kit/dist/index.node.cjs'),
+        '^react$': require.resolve('react'),
+        '^react/jsx-dev-runtime$': require.resolve('react/jsx-dev-runtime'),
+        '^react/jsx-runtime$': require.resolve('react/jsx-runtime'),
+        '^react-native$': '<rootDir>/test/mocks/react-native.js',
+        '^react-native-safe-area-context$': '<rootDir>/test/mocks/react-native-safe-area-context.js',
+    },
+    setupFilesAfterEnv: [
+        path.resolve(__dirname, 'test/jest.setup.js'),
+    ],
+    testEnvironment: 'node',
+    testMatch: ['<rootDir>/test/**/*.integration-test.ts?(x)'],
+    transformIgnorePatterns: [
+        '/node_modules/(?!.*(?:@nanostores|nanostores|uuid)/)',
+        '\\.pnp\\.[^\\/]+$',
+    ],
+    transform: {
+        '^.+\\.(ts|js)x?$': [
+            '@swc/jest',
+            {
+                jsc: {
+                    parser: {
+                        syntax: 'typescript',
+                        tsx: true,
+                    },
+                    target: 'es2020',
+                    transform: {
+                        react: {
+                            runtime: 'automatic',
+                        },
+                    },
+                },
+            },
+        ],
+    },
+};

--- a/examples/expo-kit/package.json
+++ b/examples/expo-kit/package.json
@@ -10,6 +10,7 @@
         "ios": "expo run:ios",
         "lint": "expo lint",
         "start": "expo start",
+        "test": "jest -c ./jest.config.js --runInBand",
         "web": "expo start --web"
     },
     "dependencies": {
@@ -56,7 +57,9 @@
         "@types/react": "^19.2.14",
         "eslint": "^9.25.0",
         "eslint-config-expo": "~55.0.0",
+        "jest": "^29.7.0",
         "prettier": "^3.6.2",
+        "react-test-renderer": "19.2.0",
         "typescript": "~6.0.2"
     },
     "private": true

--- a/examples/expo-kit/test/app.integration-test.tsx
+++ b/examples/expo-kit/test/app.integration-test.tsx
@@ -1,0 +1,356 @@
+/* global afterEach, beforeEach, describe, expect, it, jest */
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MobileWalletProvider } from '@wallet-ui/react-native-kit';
+import React from 'react';
+import { act, create } from 'react-test-renderer';
+import HomeScreen from '@/app/index';
+import { AppConfig } from '@/constants/app-config';
+import { NetworkProvider } from '@/features/network/network-provider';
+
+const mockTransact = jest.fn();
+
+jest.mock('@solana-mobile/mobile-wallet-adapter-protocol-kit', () => ({
+    transact: (...args: unknown[]) => mockTransact(...args),
+}), { virtual: true });
+
+const FIRST_ADDRESS = '11111111111111111111111111111111';
+const FIRST_ADDRESS_BASE64 = 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=';
+const SIGN_IN_RESULT = {
+    signature: 'sign-in-signature',
+    signed_message: 'sign-in-message',
+};
+const VALID_BLOCKHASH = '11111111111111111111111111111111';
+
+describe('expo-kit app integration', () => {
+    beforeEach(() => {
+        jest.spyOn(console, 'error').mockImplementation(() => {});
+        jest.spyOn(console, 'log').mockImplementation(() => {});
+        mockTransact.mockReset();
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    it('renders, connects, signs in, signs messages, sends transactions, and disconnects', async () => {
+        expect.assertions(15);
+
+        const cache = createMemoryCache();
+        const client = createMockClient();
+        const wallet = createMockWallet({
+            authorize: jest
+                .fn()
+                .mockResolvedValue(createAuthorizationResult())
+                .mockResolvedValueOnce(createAuthorizationResult())
+                .mockResolvedValueOnce(createAuthorizationResult({ sign_in_result: SIGN_IN_RESULT })),
+        });
+        const renderer = await renderHomeScreen({ cache, client, wallet });
+
+        await waitForCondition(() => hasText(renderer, 'Version: 2.0.0 (123)'));
+
+        expect(findButton(renderer, 'Connect')).toBeTruthy();
+        expect(hasText(renderer, 'App Config')).toBe(true);
+        expect(hasText(renderer, 'Connected to Devnet')).toBe(true);
+        expect(hasText(renderer, 'Version: 2.0.0 (123)')).toBe(true);
+
+        await pressButton(renderer, 'Connect');
+        await waitForCondition(() => hasText(renderer, 'Connected to Primary'));
+
+        expect(hasText(renderer, 'Connected to Primary')).toBe(true);
+        expect(wallet.authorize).toHaveBeenNthCalledWith(
+            1,
+            expect.objectContaining({
+                auth_token: undefined,
+                chain: 'solana:devnet',
+                identity: AppConfig.identity,
+            }),
+        );
+
+        await pressButton(renderer, 'Sign In with Primary');
+        await waitForCondition(() => wallet.authorize.mock.calls.length === 2);
+
+        expect(wallet.authorize).toHaveBeenCalledTimes(2);
+        expect(wallet.authorize).toHaveBeenNthCalledWith(2, {
+            auth_token: 'auth-token',
+            chain: 'solana:devnet',
+            identity: AppConfig.identity,
+            sign_in_payload: {
+                address: FIRST_ADDRESS,
+                chainId: 'solana:devnet',
+                uri: AppConfig.identity.uri,
+            },
+        });
+
+        await pressButton(renderer, 'Sign Message');
+        await waitForCondition(() => hasButton(renderer, 'Message Signed!'));
+
+        expect(findButton(renderer, 'Message Signed!')).toBeTruthy();
+        expect(wallet.signMessages).toHaveBeenCalledWith({
+            addresses: [FIRST_ADDRESS_BASE64],
+            payloads: [new TextEncoder().encode(`Signing a message with ${FIRST_ADDRESS}`)],
+        });
+
+        await pressButton(renderer, 'Send Multiple Transactions');
+        await waitForCondition(() => hasButton(renderer, '2 Transactions Sent!'));
+
+        expect(findButton(renderer, '2 Transactions Sent!')).toBeTruthy();
+        expect(wallet.signAndSendTransactions).toHaveBeenCalledWith(
+            expect.objectContaining({
+                minContextSlot: 42,
+                transactions: expect.any(Array),
+            }),
+        );
+
+        await pressButton(renderer, 'Disconnect');
+        await waitForCondition(() => hasButton(renderer, 'Connect') && !hasText(renderer, 'Connected to Primary'));
+
+        expect(findButton(renderer, 'Connect')).toBeTruthy();
+        expect(hasText(renderer, 'Connected to Primary')).toBe(false);
+        expect(cache.clear).toHaveBeenCalledTimes(1);
+    });
+
+    it('rehydrates a cached connection after remount without reauthorizing', async () => {
+        expect.assertions(5);
+
+        const cache = createMemoryCache();
+        const client = createMockClient();
+        const wallet = createMockWallet();
+        let renderer = await renderHomeScreen({ cache, client, wallet });
+
+        await pressButton(renderer, 'Connect');
+        await waitForCondition(() => hasText(renderer, 'Connected to Primary'));
+
+        expect(wallet.authorize).toHaveBeenCalledTimes(1);
+
+        await unmountRenderer(renderer);
+
+        renderer = await renderHomeScreen({ cache, client, wallet });
+        await waitForCondition(() => hasText(renderer, 'Connected to Primary'));
+
+        expect(cache.get).toHaveBeenCalledTimes(2);
+        expect(hasButton(renderer, 'Disconnect')).toBe(true);
+        expect(hasText(renderer, 'Connected to Primary')).toBe(true);
+        expect(wallet.authorize).toHaveBeenCalledTimes(1);
+    });
+
+    it('shows a user-visible failure when signing messages fails', async () => {
+        expect.assertions(1);
+
+        const cache = createMemoryCache();
+        const client = createMockClient();
+        const wallet = createMockWallet({
+            signMessages: jest.fn().mockRejectedValue(new Error('boom')),
+        });
+        const renderer = await renderHomeScreen({ cache, client, wallet });
+
+        await pressButton(renderer, 'Connect');
+        await waitForCondition(() => hasButton(renderer, 'Sign Message'));
+
+        await pressButton(renderer, 'Sign Message');
+        await waitForCondition(() => hasButton(renderer, 'Sign Message Failed'));
+
+        expect(findButton(renderer, 'Sign Message Failed')).toBeTruthy();
+    });
+});
+
+function createMemoryCache(initialValue?: unknown) {
+    let value = initialValue;
+
+    return {
+        clear: jest.fn(async () => {
+            value = undefined;
+        }),
+        get: jest.fn(async () => value),
+        set: jest.fn(async nextValue => {
+            value = nextValue;
+        }),
+    };
+}
+
+function createAuthorizationResult(overrides = {}) {
+    return {
+        accounts: [
+            {
+                address: FIRST_ADDRESS_BASE64,
+                label: 'Primary',
+            },
+        ],
+        auth_token: 'auth-token',
+        wallet_uri_base: 'https://wallet.example',
+        ...overrides,
+    };
+}
+
+function createMockClient() {
+    return {
+        rpc: {
+            getBalance: jest.fn(() => ({
+                send: jest.fn().mockResolvedValue({
+                    value: 2_000_000_000n,
+                }),
+            })),
+            getGenesisHash: jest.fn(() => ({
+                send: jest.fn().mockResolvedValue('GenesisHash11111111'),
+            })),
+            getLatestBlockhash: jest.fn(() => ({
+                send: jest.fn().mockResolvedValue({
+                    context: {
+                        slot: 42n,
+                    },
+                    value: {
+                        blockhash: VALID_BLOCKHASH,
+                        lastValidBlockHeight: 123n,
+                    },
+                }),
+            })),
+            getVersion: jest.fn(() => ({
+                send: jest.fn().mockResolvedValue({
+                    'feature-set': 123,
+                    'solana-core': '2.0.0',
+                }),
+            })),
+        },
+        rpcSubscriptions: {},
+    };
+}
+
+function createMockWallet({
+    authorize = jest.fn().mockResolvedValue(createAuthorizationResult()),
+    signAndSendTransactions = jest
+        .fn()
+        .mockResolvedValue([Uint8Array.from([1, 2, 3]), Uint8Array.from([4, 5, 6])]),
+    signMessages = jest.fn().mockResolvedValue([Uint8Array.from([7, 8, 9])]),
+    signTransactions = jest.fn().mockResolvedValue([{}]),
+}: {
+    authorize?: jest.Mock;
+    signAndSendTransactions?: jest.Mock;
+    signMessages?: jest.Mock;
+    signTransactions?: jest.Mock;
+} = {}) {
+    return {
+        authorize,
+        signAndSendTransactions,
+        signMessages,
+        signTransactions,
+    };
+}
+
+async function pressButton(renderer: any, title: string) {
+    await act(async () => {
+        const button = findButton(renderer, title);
+
+        if (button.props.disabled || button.props.accessibilityState?.disabled) {
+            throw new Error(`Button is disabled: ${title}`);
+        }
+
+        button.props.onPress();
+        await settle();
+    });
+}
+
+async function unmountRenderer(renderer: any) {
+    await act(async () => {
+        renderer.unmount();
+        await settle();
+    });
+}
+
+async function renderHomeScreen({
+    cache,
+    client,
+    wallet,
+}: {
+    cache: ReturnType<typeof createMemoryCache>;
+    client: ReturnType<typeof createMockClient>;
+    wallet: ReturnType<typeof createMockWallet>;
+}) {
+    mockTransact.mockImplementation(async callback => await callback(wallet));
+
+    const queryClient = new QueryClient({
+        defaultOptions: {
+            queries: {
+                retry: false,
+            },
+        },
+    });
+
+    let renderer: any;
+
+    await act(async () => {
+        renderer = create(
+            <QueryClientProvider client={queryClient}>
+                <NetworkProvider
+                    networks={AppConfig.networks}
+                    render={({ selectedNetwork }) => (
+                        <MobileWalletProvider
+                            cache={cache}
+                            cluster={selectedNetwork}
+                            createClient={() => client}
+                            identity={AppConfig.identity}
+                        >
+                            <HomeScreen />
+                        </MobileWalletProvider>
+                    )}
+                />
+            </QueryClientProvider>,
+        );
+        await settle();
+    });
+
+    return renderer;
+}
+
+function findButton(renderer: any, title: string) {
+    const button = renderer.root.findAll(
+        node => typeof node.type === 'string' && node.type === 'Button' && node.props.title === title,
+    )[0];
+
+    if (!button) {
+        throw new Error(`Button not found: ${title}`);
+    }
+
+    return button;
+}
+
+function hasButton(renderer: any, title: string) {
+    return renderer.root.findAll(
+        node => typeof node.type === 'string' && node.type === 'Button' && node.props.title === title,
+    ).length > 0;
+}
+
+function getNodeText(node: any): string {
+    return node.children
+        .map(child => {
+            if (typeof child === 'string') {
+                return child;
+            }
+            return getNodeText(child);
+        })
+        .join('');
+}
+
+function hasText(renderer: any, expected: string) {
+    return renderer.root.findAll(node => typeof node.type === 'string' && getNodeText(node) === expected).length > 0;
+}
+
+async function settle() {
+    await Promise.resolve();
+    await new Promise(resolve => setTimeout(resolve, 0));
+}
+
+async function waitForCondition(condition: () => boolean, timeoutMs = 2_000) {
+    const start = Date.now();
+
+    while (Date.now() - start < timeoutMs) {
+        if (condition()) {
+            return;
+        }
+
+        await act(async () => {
+            await settle();
+        });
+    }
+
+    throw new Error('Timed out waiting for test condition');
+}

--- a/examples/expo-kit/test/jest.setup.js
+++ b/examples/expo-kit/test/jest.setup.js
@@ -1,0 +1,28 @@
+/* global beforeEach, jest */
+
+const { Buffer } = require('buffer');
+const crypto = require('node:crypto');
+if (typeof globalThis.Buffer === 'undefined') {
+    Object.defineProperty(globalThis, 'Buffer', {
+        value: Buffer,
+        writable: true,
+    });
+}
+if (typeof globalThis.crypto === 'undefined') {
+    Object.defineProperty(globalThis, 'crypto', {
+        value: crypto.webcrypto,
+        writable: true,
+    });
+}
+if (typeof globalThis.crypto.subtle === 'undefined') {
+    Object.defineProperty(globalThis.crypto, 'subtle', {
+        value: crypto.webcrypto.subtle,
+    });
+}
+
+beforeEach(() => {
+    globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+    globalThis.__DEV__ = false;
+    globalThis.__VERSION__ = '0.0.0-test';
+    jest.restoreAllMocks();
+});

--- a/examples/expo-kit/test/mocks/async-storage.js
+++ b/examples/expo-kit/test/mocks/async-storage.js
@@ -1,0 +1,10 @@
+/* global jest */
+
+module.exports = {
+    __esModule: true,
+    default: {
+        getItem: jest.fn(),
+        removeItem: jest.fn(),
+        setItem: jest.fn(),
+    },
+};

--- a/examples/expo-kit/test/mocks/react-native-safe-area-context.js
+++ b/examples/expo-kit/test/mocks/react-native-safe-area-context.js
@@ -1,0 +1,5 @@
+const React = require('react');
+
+module.exports = {
+    SafeAreaView: ({ children, ...props }) => React.createElement('SafeAreaView', props, children),
+};

--- a/examples/expo-kit/test/mocks/react-native.js
+++ b/examples/expo-kit/test/mocks/react-native.js
@@ -1,0 +1,10 @@
+const React = require('react');
+
+module.exports = {
+    Button: ({ disabled, onPress, title }) => React.createElement('Button', { disabled, onPress, title }, title),
+    StyleSheet: {
+        create: styles => styles,
+    },
+    Text: ({ children, ...props }) => React.createElement('Text', props, children),
+    View: ({ children, ...props }) => React.createElement('View', props, children),
+};

--- a/examples/expo-web3js/features/account/account-feature-sign-message.tsx
+++ b/examples/expo-web3js/features/account/account-feature-sign-message.tsx
@@ -1,21 +1,26 @@
 import { PublicKey } from '@solana/web3.js';
 import { Button, View } from 'react-native';
 import { appStyles } from '@/constants/app-styles';
-import { toUint8Array, useMobileWallet } from '@wallet-ui/react-native-web3js';
+import { useMobileWallet } from '@wallet-ui/react-native-web3js';
+import { useState } from 'react';
 
 export function AccountFeatureSignMessage({ address }: { address: PublicKey }) {
     const { signMessages } = useMobileWallet();
+    const [title, setTitle] = useState('Sign Message');
+
     async function submit() {
         try {
-            await signMessages(toUint8Array(`Signing a message with ${address.toString()}`));
+            await signMessages(new TextEncoder().encode(`Signing a message with ${address.toString()}`));
+            setTitle('Message Signed!');
             console.log('Message signed!');
         } catch (e) {
+            setTitle('Sign Message Failed');
             console.log(`Error signing message: ${e}`);
         }
     }
     return (
         <View style={appStyles.stack}>
-            <Button onPress={submit} title="Sign Message" />
+            <Button onPress={submit} title={title} />
         </View>
     );
 }

--- a/examples/expo-web3js/jest.config.js
+++ b/examples/expo-web3js/jest.config.js
@@ -1,0 +1,48 @@
+/* global __dirname */
+
+const path = require('path');
+
+module.exports = {
+    clearMocks: true,
+    moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json'],
+    moduleNameMapper: {
+        '^@/(.*)$': '<rootDir>/$1',
+        '^@react-native-async-storage/async-storage$': '<rootDir>/test/mocks/async-storage.js',
+        '^@solana/kit$': require.resolve('@solana/kit'),
+        '^@wallet-ui/core$': path.resolve(__dirname, '../../packages/core/dist/index.node.cjs'),
+        '^@wallet-ui/react-native-web3js$': path.resolve(__dirname, '../../packages/react-native-web3js/dist/index.node.cjs'),
+        '^react$': require.resolve('react'),
+        '^react/jsx-dev-runtime$': require.resolve('react/jsx-dev-runtime'),
+        '^react/jsx-runtime$': require.resolve('react/jsx-runtime'),
+        '^react-native$': '<rootDir>/test/mocks/react-native.js',
+        '^react-native-safe-area-context$': '<rootDir>/test/mocks/react-native-safe-area-context.js',
+    },
+    setupFilesAfterEnv: [
+        path.resolve(__dirname, 'test/jest.setup.js'),
+    ],
+    testEnvironment: 'node',
+    testMatch: ['<rootDir>/test/**/*.integration-test.ts?(x)'],
+    transformIgnorePatterns: [
+        '/node_modules/(?!.*(?:@nanostores|nanostores|uuid)/)',
+        '\\.pnp\\.[^\\/]+$',
+    ],
+    transform: {
+        '^.+\\.(ts|js)x?$': [
+            '@swc/jest',
+            {
+                jsc: {
+                    parser: {
+                        syntax: 'typescript',
+                        tsx: true,
+                    },
+                    target: 'es2020',
+                    transform: {
+                        react: {
+                            runtime: 'automatic',
+                        },
+                    },
+                },
+            },
+        ],
+    },
+};

--- a/examples/expo-web3js/package.json
+++ b/examples/expo-web3js/package.json
@@ -10,6 +10,7 @@
     "ios": "expo run:ios",
     "lint": "expo lint",
     "start": "expo start",
+    "test": "jest -c ./jest.config.js --runInBand",
     "web": "expo start --web"
   },
   "dependencies": {
@@ -54,7 +55,9 @@
     "@types/react": "^19.2.14",
     "eslint": "^9.25.0",
     "eslint-config-expo": "~55.0.0",
+    "jest": "^29.7.0",
     "prettier": "^3.6.2",
+    "react-test-renderer": "19.2.0",
     "typescript": "~6.0.2"
   },
   "private": true

--- a/examples/expo-web3js/test/app.integration-test.tsx
+++ b/examples/expo-web3js/test/app.integration-test.tsx
@@ -1,0 +1,349 @@
+/* global afterEach, beforeEach, describe, expect, it, jest */
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MobileWalletProvider } from '@wallet-ui/react-native-web3js';
+import React from 'react';
+import { act, create } from 'react-test-renderer';
+import HomeScreen from '@/app/index';
+import { AppConfig } from '@/constants/app-config';
+import { NetworkProvider } from '@/features/network/network-provider';
+
+const mockConnectionConstructor = jest.fn();
+const mockTransact = jest.fn();
+
+jest.mock('@solana-mobile/mobile-wallet-adapter-protocol-web3js', () => ({
+    transact: (...args: unknown[]) => mockTransact(...args),
+}), { virtual: true });
+
+jest.mock('@solana/web3.js', () => {
+    const actual = jest.requireActual('@solana/web3.js');
+
+    return {
+        ...actual,
+        Connection: jest.fn((...args: unknown[]) => mockConnectionConstructor(...args)),
+    };
+});
+
+const FIRST_ADDRESS = '11111111111111111111111111111111';
+const FIRST_ADDRESS_BASE64 = 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=';
+const SIGN_IN_RESULT = {
+    signature: 'sign-in-signature',
+    signed_message: 'sign-in-message',
+};
+const VALID_BLOCKHASH = '11111111111111111111111111111111';
+
+describe('expo-web3js app integration', () => {
+    beforeEach(() => {
+        jest.spyOn(console, 'error').mockImplementation(() => {});
+        jest.spyOn(console, 'log').mockImplementation(() => {});
+        mockConnectionConstructor.mockReset();
+        mockTransact.mockReset();
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    it('renders, connects, signs in, signs messages, sends transactions, and disconnects', async () => {
+        expect.assertions(16);
+
+        const cache = createMemoryCache();
+        const connection = createMockConnection();
+        const wallet = createMockWallet({
+            authorize: jest
+                .fn()
+                .mockResolvedValue(createAuthorizationResult())
+                .mockResolvedValueOnce(createAuthorizationResult())
+                .mockResolvedValueOnce(createAuthorizationResult({ sign_in_result: SIGN_IN_RESULT })),
+        });
+        const renderer = await renderHomeScreen({ cache, connection, wallet });
+
+        await waitForCondition(() => hasText(renderer, 'Version: 2.0.0 (123)'));
+
+        expect(findButton(renderer, 'Connect')).toBeTruthy();
+        expect(hasText(renderer, 'App Config')).toBe(true);
+        expect(hasText(renderer, 'Connected to Devnet')).toBe(true);
+        expect(hasText(renderer, 'Version: 2.0.0 (123)')).toBe(true);
+
+        await pressButton(renderer, 'Connect');
+        await waitForCondition(() => hasText(renderer, 'Connected to Primary'));
+
+        expect(hasText(renderer, 'Connected to Primary')).toBe(true);
+        expect(wallet.authorize).toHaveBeenNthCalledWith(
+            1,
+            expect.objectContaining({
+                auth_token: undefined,
+                chain: 'solana:devnet',
+                identity: AppConfig.identity,
+            }),
+        );
+
+        await pressButton(renderer, 'Sign In with Primary');
+        await waitForCondition(() => wallet.authorize.mock.calls.length === 2);
+
+        expect(wallet.authorize).toHaveBeenCalledTimes(2);
+        expect(wallet.authorize).toHaveBeenNthCalledWith(2, {
+            auth_token: 'auth-token',
+            chain: 'solana:devnet',
+            identity: AppConfig.identity,
+            sign_in_payload: {
+                address: FIRST_ADDRESS,
+                uri: AppConfig.identity.uri,
+            },
+        });
+
+        await pressButton(renderer, 'Sign Message');
+        await waitForCondition(() => hasButton(renderer, 'Message Signed!'));
+
+        expect(findButton(renderer, 'Message Signed!')).toBeTruthy();
+        expect(wallet.signMessages).toHaveBeenCalledWith({
+            addresses: [FIRST_ADDRESS_BASE64],
+            payloads: [new TextEncoder().encode(`Signing a message with ${FIRST_ADDRESS}`)],
+        });
+
+        await pressButton(renderer, 'Send Multiple Transactions');
+        await waitForCondition(() => hasButton(renderer, '2 Transactions Sent!'));
+
+        expect(findButton(renderer, '2 Transactions Sent!')).toBeTruthy();
+        expect(connection.confirmTransaction).toHaveBeenCalledTimes(2);
+        expect(wallet.signAndSendTransactions).toHaveBeenCalledWith(
+            expect.objectContaining({
+                minContextSlot: 42,
+                transactions: expect.any(Array),
+            }),
+        );
+
+        await pressButton(renderer, 'Disconnect');
+        await waitForCondition(() => hasButton(renderer, 'Connect') && !hasText(renderer, 'Connected to Primary'));
+
+        expect(findButton(renderer, 'Connect')).toBeTruthy();
+        expect(hasText(renderer, 'Connected to Primary')).toBe(false);
+        expect(cache.clear).toHaveBeenCalledTimes(1);
+    });
+
+    it('rehydrates a cached connection after remount without reauthorizing', async () => {
+        expect.assertions(5);
+
+        const cache = createMemoryCache();
+        const connection = createMockConnection();
+        const wallet = createMockWallet();
+        let renderer = await renderHomeScreen({ cache, connection, wallet });
+
+        await pressButton(renderer, 'Connect');
+        await waitForCondition(() => hasText(renderer, 'Connected to Primary'));
+
+        expect(wallet.authorize).toHaveBeenCalledTimes(1);
+
+        await unmountRenderer(renderer);
+
+        renderer = await renderHomeScreen({ cache, connection, wallet });
+        await waitForCondition(() => hasText(renderer, 'Connected to Primary'));
+
+        expect(cache.get).toHaveBeenCalledTimes(2);
+        expect(hasButton(renderer, 'Disconnect')).toBe(true);
+        expect(hasText(renderer, 'Connected to Primary')).toBe(true);
+        expect(wallet.authorize).toHaveBeenCalledTimes(1);
+    });
+
+    it('shows a user-visible failure when signing messages fails', async () => {
+        expect.assertions(1);
+
+        const cache = createMemoryCache();
+        const connection = createMockConnection();
+        const wallet = createMockWallet({
+            signMessages: jest.fn().mockRejectedValue(new Error('boom')),
+        });
+        const renderer = await renderHomeScreen({ cache, connection, wallet });
+
+        await pressButton(renderer, 'Connect');
+        await waitForCondition(() => hasButton(renderer, 'Sign Message'));
+
+        await pressButton(renderer, 'Sign Message');
+        await waitForCondition(() => hasButton(renderer, 'Sign Message Failed'));
+
+        expect(findButton(renderer, 'Sign Message Failed')).toBeTruthy();
+    });
+});
+
+function createMemoryCache(initialValue?: unknown) {
+    let value = initialValue;
+
+    return {
+        clear: jest.fn(async () => {
+            value = undefined;
+        }),
+        get: jest.fn(async () => value),
+        set: jest.fn(async nextValue => {
+            value = nextValue;
+        }),
+    };
+}
+
+function createAuthorizationResult(overrides = {}) {
+    return {
+        accounts: [
+            {
+                address: FIRST_ADDRESS_BASE64,
+                label: 'Primary',
+            },
+        ],
+        auth_token: 'auth-token',
+        wallet_uri_base: 'https://wallet.example',
+        ...overrides,
+    };
+}
+
+function createMockConnection() {
+    return {
+        confirmTransaction: jest.fn().mockResolvedValue(undefined),
+        getBalance: jest.fn().mockResolvedValue(2_000_000_000),
+        getGenesisHash: jest.fn().mockResolvedValue('GenesisHash11111111'),
+        getLatestBlockhashAndContext: jest.fn().mockResolvedValue({
+            context: {
+                slot: 42,
+            },
+            value: {
+                blockhash: VALID_BLOCKHASH,
+                lastValidBlockHeight: 123,
+            },
+        }),
+        getVersion: jest.fn().mockResolvedValue({
+            'feature-set': 123,
+            'solana-core': '2.0.0',
+        }),
+    };
+}
+
+function createMockWallet({
+    authorize = jest.fn().mockResolvedValue(createAuthorizationResult()),
+    signAndSendTransactions = jest.fn().mockResolvedValue(['signature-1', 'signature-2']),
+    signMessages = jest.fn().mockResolvedValue([Uint8Array.from([1, 2, 3])]),
+    signTransactions = jest.fn().mockResolvedValue([{}]),
+}: {
+    authorize?: jest.Mock;
+    signAndSendTransactions?: jest.Mock;
+    signMessages?: jest.Mock;
+    signTransactions?: jest.Mock;
+} = {}) {
+    return {
+        authorize,
+        signAndSendTransactions,
+        signMessages,
+        signTransactions,
+    };
+}
+
+async function pressButton(renderer: any, title: string) {
+    await act(async () => {
+        const button = findButton(renderer, title);
+
+        if (button.props.disabled || button.props.accessibilityState?.disabled) {
+            throw new Error(`Button is disabled: ${title}`);
+        }
+
+        button.props.onPress();
+        await settle();
+    });
+}
+
+async function unmountRenderer(renderer: any) {
+    await act(async () => {
+        renderer.unmount();
+        await settle();
+    });
+}
+
+async function renderHomeScreen({
+    cache,
+    connection,
+    wallet,
+}: {
+    cache: ReturnType<typeof createMemoryCache>;
+    connection: ReturnType<typeof createMockConnection>;
+    wallet: ReturnType<typeof createMockWallet>;
+}) {
+    mockConnectionConstructor.mockImplementation(() => connection);
+    mockTransact.mockImplementation(async callback => await callback(wallet));
+
+    const queryClient = new QueryClient({
+        defaultOptions: {
+            queries: {
+                retry: false,
+            },
+        },
+    });
+
+    let renderer: any;
+
+    await act(async () => {
+        renderer = create(
+            <QueryClientProvider client={queryClient}>
+                <NetworkProvider
+                    networks={AppConfig.networks}
+                    render={({ chain, endpoint }) => (
+                        <MobileWalletProvider cache={cache} chain={chain} endpoint={endpoint} identity={AppConfig.identity}>
+                            <HomeScreen />
+                        </MobileWalletProvider>
+                    )}
+                />
+            </QueryClientProvider>,
+        );
+        await settle();
+    });
+
+    return renderer;
+}
+
+function findButton(renderer: any, title: string) {
+    const button = renderer.root.findAll(
+        node => typeof node.type === 'string' && node.type === 'Button' && node.props.title === title,
+    )[0];
+
+    if (!button) {
+        throw new Error(`Button not found: ${title}`);
+    }
+
+    return button;
+}
+
+function hasButton(renderer: any, title: string) {
+    return renderer.root.findAll(
+        node => typeof node.type === 'string' && node.type === 'Button' && node.props.title === title,
+    ).length > 0;
+}
+
+function getNodeText(node: any): string {
+    return node.children
+        .map(child => {
+            if (typeof child === 'string') {
+                return child;
+            }
+            return getNodeText(child);
+        })
+        .join('');
+}
+
+function hasText(renderer: any, expected: string) {
+    return renderer.root.findAll(node => typeof node.type === 'string' && getNodeText(node) === expected).length > 0;
+}
+
+async function settle() {
+    await Promise.resolve();
+    await new Promise(resolve => setTimeout(resolve, 0));
+}
+
+async function waitForCondition(condition: () => boolean, timeoutMs = 2_000) {
+    const start = Date.now();
+
+    while (Date.now() - start < timeoutMs) {
+        if (condition()) {
+            return;
+        }
+
+        await act(async () => {
+            await settle();
+        });
+    }
+
+    throw new Error('Timed out waiting for test condition');
+}

--- a/examples/expo-web3js/test/jest.setup.js
+++ b/examples/expo-web3js/test/jest.setup.js
@@ -1,0 +1,28 @@
+/* global beforeEach, jest */
+
+const { Buffer } = require('buffer');
+const crypto = require('node:crypto');
+if (typeof globalThis.Buffer === 'undefined') {
+    Object.defineProperty(globalThis, 'Buffer', {
+        value: Buffer,
+        writable: true,
+    });
+}
+if (typeof globalThis.crypto === 'undefined') {
+    Object.defineProperty(globalThis, 'crypto', {
+        value: crypto.webcrypto,
+        writable: true,
+    });
+}
+if (typeof globalThis.crypto.subtle === 'undefined') {
+    Object.defineProperty(globalThis.crypto, 'subtle', {
+        value: crypto.webcrypto.subtle,
+    });
+}
+
+beforeEach(() => {
+    globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+    globalThis.__DEV__ = false;
+    globalThis.__VERSION__ = '0.0.0-test';
+    jest.restoreAllMocks();
+});

--- a/examples/expo-web3js/test/mocks/async-storage.js
+++ b/examples/expo-web3js/test/mocks/async-storage.js
@@ -1,0 +1,10 @@
+/* global jest */
+
+module.exports = {
+    __esModule: true,
+    default: {
+        getItem: jest.fn(),
+        removeItem: jest.fn(),
+        setItem: jest.fn(),
+    },
+};

--- a/examples/expo-web3js/test/mocks/react-native-safe-area-context.js
+++ b/examples/expo-web3js/test/mocks/react-native-safe-area-context.js
@@ -1,0 +1,5 @@
+const React = require('react');
+
+module.exports = {
+    SafeAreaView: ({ children, ...props }) => React.createElement('SafeAreaView', props, children),
+};

--- a/examples/expo-web3js/test/mocks/react-native.js
+++ b/examples/expo-web3js/test/mocks/react-native.js
@@ -1,0 +1,10 @@
+const React = require('react');
+
+module.exports = {
+    Button: ({ disabled, onPress, title }) => React.createElement('Button', { disabled, onPress, title }, title),
+    StyleSheet: {
+        create: styles => styles,
+    },
+    Text: ({ children, ...props }) => React.createElement('Text', props, children),
+    View: ({ children, ...props }) => React.createElement('View', props, children),
+};

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
         "compile": "turbo run --concurrency=${TURBO_CONCURRENCY:-95.84%} compile:js compile:typedefs",
         "lint": "turbo run --concurrency=${TURBO_CONCURRENCY:-95.84%} test:lint",
         "style:fix": "turbo  run --concurrency=${TURBO_CONCURRENCY:-95.84%} style:fix && pnpm prettier --log-level warn --ignore-unknown --write '{.,!packages}/*'",
-        "test": "turbo run --concurrency=${TURBO_CONCURRENCY:-95.84%} test:unit:browser test:unit:node",
+        "test": "turbo run --concurrency=${TURBO_CONCURRENCY:-95.84%} test:unit:browser test:unit:node && pnpm test:examples",
+        "test:examples": "pnpm --dir examples/expo-kit test && pnpm --dir examples/expo-web3js test",
         "test:live-with-test-validator": "turbo run --concurrency=${TURBO_CONCURRENCY:-95.84%} test:live-with-test-validator",
         "test:live-with-test-validator:setup": "./scripts/setup-test-validator.sh"
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -232,7 +232,7 @@ importers:
         version: 55.0.9(expo@55.0.9)(react-native@0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)(typescript@6.0.2)
       expo-router:
         specifier: ~55.0.8
-        version: 55.0.8(6df5edb65d27401d90e5d77b2016246d)
+        version: 55.0.8(68e2cb8634aa280894cf9251c9ce289f)
       expo-splash-screen:
         specifier: ~55.0.13
         version: 55.0.13(expo@55.0.9)(typescript@6.0.2)
@@ -294,9 +294,15 @@ importers:
       eslint-config-expo:
         specifier: ~55.0.0
         version: 55.0.0(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.2)
+      jest:
+        specifier: ^29.7.0
+        version: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@swc/core@1.13.5(@swc/helpers@0.5.18))(@types/node@24.10.1)(typescript@6.0.2))
       prettier:
         specifier: ^3.6.2
         version: 3.6.2
+      react-test-renderer:
+        specifier: 19.2.0
+        version: 19.2.0(react@19.2.0)
       typescript:
         specifier: ~6.0.2
         version: 6.0.2
@@ -362,7 +368,7 @@ importers:
         version: 55.0.9(expo@55.0.9)(react-native@0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)(typescript@6.0.2)
       expo-router:
         specifier: ~55.0.8
-        version: 55.0.8(6df5edb65d27401d90e5d77b2016246d)
+        version: 55.0.8(3326c468d016b2779095fe21d9c3c8f2)
       expo-splash-screen:
         specifier: ~55.0.13
         version: 55.0.13(expo@55.0.9)(typescript@6.0.2)
@@ -421,9 +427,15 @@ importers:
       eslint-config-expo:
         specifier: ~55.0.0
         version: 55.0.0(eslint@9.37.0(jiti@2.6.1))(typescript@6.0.2)
+      jest:
+        specifier: ^29.7.0
+        version: 29.7.0(@types/node@25.3.1)(ts-node@10.9.2(@swc/core@1.13.5(@swc/helpers@0.5.18))(@types/node@25.3.1)(typescript@6.0.2))
       prettier:
         specifier: ^3.6.2
         version: 3.6.2
+      react-test-renderer:
+        specifier: 19.2.0
+        version: 19.2.0(react@19.2.0)
       typescript:
         specifier: ~6.0.2
         version: 6.0.2
@@ -1638,10 +1650,6 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
-
-  '@babel/runtime@7.28.4':
-    resolution: {integrity: sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==}
-    engines: {node: '>=6.9.0'}
 
   '@babel/runtime@7.28.6':
     resolution: {integrity: sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==}
@@ -2862,6 +2870,10 @@ packages:
     resolution: {integrity: sha512-kZ/tNpS3NXn0mlXXXPNuDZnb4c0oZ20r4K5eemM2k30ZC3G0T02nXUvyhf5YdbXWHPEJLc9qGLxEZ216MdL+Zg==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
 
+  '@jest/console@29.7.0':
+    resolution: {integrity: sha512-5Ni4CU7XHQi32IJ398EEP4RrB8eV09sXP2ROqD4bksHrnTree52PsxvX8tpL8LvTZ3pFzXyPbNQReSN41CAhOg==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
   '@jest/console@30.1.2':
     resolution: {integrity: sha512-BGMAxj8VRmoD0MoA/jo9alMXSRoqW8KPeqOfEo1ncxnRLatTBCpRoOwlwlEMdudp68Q6WSGwYrrLtTGOh8fLzw==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
@@ -2869,6 +2881,15 @@ packages:
   '@jest/console@30.2.0':
     resolution: {integrity: sha512-+O1ifRjkvYIkBqASKWgLxrpEhQAAE7hY77ALLUufSk5717KfOShg6IbqLmdsLMPdUiFvA2kTs0R7YZy+l0IzZQ==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  '@jest/core@29.7.0':
+    resolution: {integrity: sha512-n7aeXWKMnGtDA48y8TLWJPJmLmmZ642Ceo78cYWEpiD7FzDgmNDV/GCVRorPABdXLJZ/9wzzgZAlHjXjxDHGsg==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    peerDependencies:
+      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
+    peerDependenciesMeta:
+      node-notifier:
+        optional: true
 
   '@jest/core@30.2.0':
     resolution: {integrity: sha512-03W6IhuhjqTlpzh/ojut/pDB2LPRygyWX8ExpgHtQA8H/3K7+1vKmcINx5UzeOX1se6YEsBsOHQ1CRzf3fOwTQ==}
@@ -2913,6 +2934,10 @@ packages:
     resolution: {integrity: sha512-/QPTL7OBJQ5ac09UDRa3EQes4gt1FTEG/8jZ/4v5IVzx+Cv7dLxlVIvfvSVRiiX2drWyXeBjkMSR8hvOWSog5g==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
+  '@jest/expect-utils@29.7.0':
+    resolution: {integrity: sha512-GlsNBWiFQFCVi9QVSx7f5AgMeLxe9YCCs5PuP2O2LdjDAA8Jh9eX7lA1Jq/xdXw3Wb3hyvlFNfZIfcRetSzYcA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
   '@jest/expect-utils@30.1.2':
     resolution: {integrity: sha512-HXy1qT/bfdjCv7iC336ExbqqYtZvljrV8odNdso7dWK9bSeHtLlvwWWC3YSybSPL03Gg5rug6WLCZAZFH72m0A==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
@@ -2920,6 +2945,10 @@ packages:
   '@jest/expect-utils@30.2.0':
     resolution: {integrity: sha512-1JnRfhqpD8HGpOmQp180Fo9Zt69zNtC+9lR+kT7NVL05tNXIi+QC8Csz7lfidMoVLPD3FnOtcmp0CEFnxExGEA==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  '@jest/expect@29.7.0':
+    resolution: {integrity: sha512-8uMeAMycttpva3P1lBHB8VciS9V0XAr3GymPpipdyQXbBcuhkLQOSe8E/p92RyAdToS6ZD1tFkX+CkhoECE0dQ==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
   '@jest/expect@30.2.0':
     resolution: {integrity: sha512-V9yxQK5erfzx99Sf+7LbhBwNWEZ9eZay8qQ9+JSC0TrMR1pMDHLMY+BnVPacWU6Jamrh252/IKo4F1Xn/zfiqA==}
@@ -2945,6 +2974,10 @@ packages:
     resolution: {integrity: sha512-ZEJNB41OBQQgGzgyInAv0UUfDDj3upmHydjieSxFvTRuZElrx7tXg/uVQ5hYVEwiXs3+aMsAeEc9X7xiSKCm4Q==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
 
+  '@jest/globals@29.7.0':
+    resolution: {integrity: sha512-mpiz3dutLbkW2MNFubUGUEVLkTGiqW6yLVTA+JbP6fI6J5iL9Y0Nlg8k95pcF8ctKwCS7WVxteBs29hhfAotzQ==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
   '@jest/globals@30.2.0':
     resolution: {integrity: sha512-b63wmnKPaK+6ZZfpYhz9K61oybvbI1aMcIs80++JI1O1rR1vaxHUCNqo3ITu6NU0d4V34yZFoHMn/uoKr/Rwfw==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
@@ -2952,6 +2985,15 @@ packages:
   '@jest/pattern@30.0.1':
     resolution: {integrity: sha512-gWp7NfQW27LaBQz3TITS8L7ZCQ0TLvtmI//4OwlQRx4rnWxcPNIYjxZpDcN4+UlGxgm3jS5QPz8IPTCkb59wZA==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  '@jest/reporters@29.7.0':
+    resolution: {integrity: sha512-DApq0KJbJOEzAFYjHADNNxAE3KbhxQB1y5Kplb5Waqw6zVbuWatSnMjE5gs8FUgEPmNsnZA3NCWl9NG0ia04Pg==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    peerDependencies:
+      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
+    peerDependenciesMeta:
+      node-notifier:
+        optional: true
 
   '@jest/reporters@30.2.0':
     resolution: {integrity: sha512-DRyW6baWPqKMa9CzeiBjHwjd8XeAyco2Vt8XbcLFjiwCOEKOvy82GJ8QQnJE9ofsxCMPjH4MfH8fCWIHHDKpAQ==}
@@ -2978,6 +3020,10 @@ packages:
     resolution: {integrity: sha512-y9NIHUYF3PJRlHk98NdC/N1gl88BL08aQQgu4k4ZopQkCw9t9cV8mtl3TV8b/YCB8XaVTFrmUTAJvjsntDireg==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
 
+  '@jest/source-map@29.6.3':
+    resolution: {integrity: sha512-MHjT95QuipcPrpLM+8JMSzFx6eHp5Bm+4XeFDJlwsvVBjmKNiIAvasGK2fxz2WbGRlnvqehFbh07MMa7n3YJnw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
   '@jest/source-map@30.0.1':
     resolution: {integrity: sha512-MIRWMUUR3sdbP36oyNyhbThLHyJ2eEDClPCiHVbrYAe5g3CHRArIVpBw7cdSB5fr+ofSfIb2Tnsw8iEHL0PYQg==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
@@ -2986,6 +3032,10 @@ packages:
     resolution: {integrity: sha512-EW35l2RYFUcUQxFJz5Cv5MTOxlJIQs4I7gxzi2zVU7PJhOwfYq1MdC5nhSmYjX1gmMmLPvB3sIaC+BkcHRBfag==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
 
+  '@jest/test-result@29.7.0':
+    resolution: {integrity: sha512-Fdx+tv6x1zlkJPcWXmMDAG2HBnaR9XPSd5aDWQVsfrZmLVT3lU1cwyxLgRmXR9yrq4NBoEm9BMsfgFzTQAbJYA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
   '@jest/test-result@30.1.3':
     resolution: {integrity: sha512-P9IV8T24D43cNRANPPokn7tZh0FAFnYS2HIfi5vK18CjRkTDR9Y3e1BoEcAJnl4ghZZF4Ecda4M/k41QkvurEQ==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
@@ -2993,6 +3043,10 @@ packages:
   '@jest/test-result@30.2.0':
     resolution: {integrity: sha512-RF+Z+0CCHkARz5HT9mcQCBulb1wgCP3FBvl9VFokMX27acKphwyQsNuWH3c+ojd1LeWBLoTYoxF0zm6S/66mjg==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  '@jest/test-sequencer@29.7.0':
+    resolution: {integrity: sha512-GQwJ5WZVrKnOJuiYiAF52UNUJXgTZx1NHjFSEB0qEMmSZKAkdMoIzw/Cj6x6NF4AvV23AUqDpFzQkN/eYCYTxw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
   '@jest/test-sequencer@30.2.0':
     resolution: {integrity: sha512-wXKgU/lk8fKXMu/l5Hog1R61bL4q5GCdT6OJvdAFz1P+QrpoFuLU68eoKuVc4RbrTtNnTL5FByhWdLgOPSph+Q==}
@@ -5144,6 +5198,18 @@ packages:
     peerDependencies:
       react: ^18 || ^19
 
+  '@testing-library/react-native@13.3.3':
+    resolution: {integrity: sha512-k6Mjsd9dbZgvY4Bl7P1NIpePQNi+dfYtlJ5voi9KQlynxSyQkfOgJmYGCYmw/aSgH/rUcFvG8u5gd4npzgRDyg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      jest: '>=29.0.0'
+      react: '>=18.2.0'
+      react-native: '>=0.71'
+      react-test-renderer: '>=18.2.0'
+    peerDependenciesMeta:
+      jest:
+        optional: true
+
   '@tootallnate/once@2.0.0':
     resolution: {integrity: sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==}
     engines: {node: '>= 10'}
@@ -6182,8 +6248,8 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
-  baseline-browser-mapping@2.10.16:
-    resolution: {integrity: sha512-Lyf3aK28zpsD1yQMiiHD4RvVb6UdMoo8xzG2XzFIfR9luPzOpcBlAsT/qfB1XWS1bxWT+UtE4WmQgsp297FYOA==}
+  baseline-browser-mapping@2.10.17:
+    resolution: {integrity: sha512-HdrkN8eVG2CXxeifv/VdJ4A4RSra1DTW8dc/hdxzhGHN8QePs6gKaWM9pHPcpCoxYZJuOZ8drHmbdpLHjCYjLA==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -6599,6 +6665,11 @@ packages:
     resolution: {integrity: sha512-NjiIqN9LFEoFrNyDib00DW1x5jZuK32FiyYyul8YcJMzw32c4ied16mWP99ekGJXMMagroAvkU0Umvuqtnqy8Q==}
     hasBin: true
 
+  create-jest@29.7.0:
+    resolution: {integrity: sha512-Adz2bdH0Vq3F53KEMJOoftQFutWCukm6J24wbPWRO4k1kMY7gS7ds/uoJkNuV8wDCtWWnuwGcJwpWcih+zEW1Q==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    hasBin: true
+
   create-require@1.1.1:
     resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
 
@@ -6808,6 +6879,10 @@ packages:
   diff-sequences@27.5.1:
     resolution: {integrity: sha512-k1gCAXAsNgLwEL+Y8Wvl+M6oEFj5bgazfZULpS5CneoPPXRaCCW7dm+q21Ky2VEE5X+VeRDBVg1Pcvvsr4TtNQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
+  diff-sequences@29.6.3:
+    resolution: {integrity: sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
   diff@4.0.2:
     resolution: {integrity: sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==}
@@ -7308,6 +7383,10 @@ packages:
     resolution: {integrity: sha512-+I6B/IkJc1o/2tiURyz/ivu/O0nKNEArIUB5O7zBrlDVJr22SCLH3xTeEry428LvFhRzIA1g8izguxJ/gbNcVQ==}
     engines: {node: '>= 0.8.0'}
 
+  exit@0.1.2:
+    resolution: {integrity: sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==}
+    engines: {node: '>= 0.8.0'}
+
   expand-tilde@1.2.2:
     resolution: {integrity: sha512-rtmc+cjLZqnu9dSYosX9EWmSJhTwpACgJQTfj4hgg2JjOD/6SIQalZrt4a3aQeh++oNxkazcaxrhPUj6+g5G/Q==}
     engines: {node: '>=0.10.0'}
@@ -7315,6 +7394,10 @@ packages:
   expect@27.5.1:
     resolution: {integrity: sha512-E1q5hSUG2AmYQwQJ041nvgpkODHQvB+RKlB4IYdru6uJsyFTRyZAP463M+1lINorwbqAmUggi6+WwkD8lCS/Dw==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
+  expect@29.7.0:
+    resolution: {integrity: sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
   expect@30.1.2:
     resolution: {integrity: sha512-xvHszRavo28ejws8FpemjhwswGj4w/BetHIL8cU49u4sGyXDw2+p3YbeDbj6xzlxi6kWTjIRSTJ+9sNXPnF0Zg==}
@@ -8090,6 +8173,10 @@ packages:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
 
+  indent-string@4.0.0:
+    resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
+    engines: {node: '>=8'}
+
   inflight@1.0.6:
     resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
     deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
@@ -8345,6 +8432,10 @@ packages:
     resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
     engines: {node: '>=10'}
 
+  istanbul-lib-source-maps@4.0.1:
+    resolution: {integrity: sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==}
+    engines: {node: '>=10'}
+
   istanbul-lib-source-maps@5.0.6:
     resolution: {integrity: sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==}
     engines: {node: '>=10'}
@@ -8365,13 +8456,31 @@ packages:
     engines: {node: '>=8'}
     hasBin: true
 
+  jest-changed-files@29.7.0:
+    resolution: {integrity: sha512-fEArFiwf1BpQ+4bXSprcDc3/x4HSzL4al2tozwVpDFpsxALjLYdyiIK4e5Vz66GQJIbXJ82+35PtysofptNX2w==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
   jest-changed-files@30.2.0:
     resolution: {integrity: sha512-L8lR1ChrRnSdfeOvTrwZMlnWV8G/LLjQ0nG9MBclwWZidA2N5FviRki0Bvh20WRMOX31/JYvzdqTJrk5oBdydQ==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
+  jest-circus@29.7.0:
+    resolution: {integrity: sha512-3E1nCMgipcTkCocFwM90XXQab9bS+GMsjdpmPrlelaxwD93Ad8iVEjX/vvHPdLPnFf+L40u+5+iutRdA1N9myw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
   jest-circus@30.2.0:
     resolution: {integrity: sha512-Fh0096NC3ZkFx05EP2OXCxJAREVxj1BcW/i6EWqqymcgYKWjyyDpral3fMxVcHXg6oZM7iULer9wGRFvfpl+Tg==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  jest-cli@29.7.0:
+    resolution: {integrity: sha512-OVVobw2IubN/GSYsxETi+gOe7Ka59EFMR/twOU3Jb2GnKKeMGJB5SGUUrEz3SFVmJASUdZUzy83sLNNQ2gZslg==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    hasBin: true
+    peerDependencies:
+      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
+    peerDependenciesMeta:
+      node-notifier:
+        optional: true
 
   jest-cli@30.2.0:
     resolution: {integrity: sha512-Os9ukIvADX/A9sLt6Zse3+nmHtHaE6hqOsjQtNiugFTbKRHYIYtZXNGNK9NChseXy7djFPjndX1tL0sCTlfpAA==}
@@ -8381,6 +8490,18 @@ packages:
       node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
     peerDependenciesMeta:
       node-notifier:
+        optional: true
+
+  jest-config@29.7.0:
+    resolution: {integrity: sha512-uXbpfeQ7R6TZBqI3/TxCU4q4ttk3u0PJeC+E0zbfSoSjq6bJ7buBPxzQPL0ifrkY4DNu4JUdk0ImlBUYi840eQ==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    peerDependencies:
+      '@types/node': '*'
+      ts-node: '>=9.0.0'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      ts-node:
         optional: true
 
   jest-config@30.2.0:
@@ -8406,6 +8527,10 @@ packages:
     resolution: {integrity: sha512-m0NvkX55LDt9T4mctTEgnZk3fmEg3NRYutvMPWM/0iPnkFj2wIeF45O1718cMSOFO1vINkqmxqD8vE37uTEbqw==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
 
+  jest-diff@29.7.0:
+    resolution: {integrity: sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
   jest-diff@30.1.2:
     resolution: {integrity: sha512-4+prq+9J61mOVXCa4Qp8ZjavdxzrWQXrI80GNxP8f4tkI2syPuPrJgdRPZRrfUTRvIoUwcmNLbqEJy9W800+NQ==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
@@ -8418,9 +8543,17 @@ packages:
     resolution: {integrity: sha512-rl7hlABeTsRYxKiUfpHrQrG4e2obOiTQWfMEH3PxPjOtdsfLQO4ReWSZaQ7DETm4xu07rl4q/h4zcKXyU0/OzQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
 
+  jest-docblock@29.7.0:
+    resolution: {integrity: sha512-q617Auw3A612guyaFgsbFeYpNP5t2aoUNLwBUbc/0kD1R4t9ixDbyFTHd1nok4epoVFpr7PmeWHrhvuV3XaJ4g==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
   jest-docblock@30.2.0:
     resolution: {integrity: sha512-tR/FFgZKS1CXluOQzZvNH3+0z9jXr3ldGSD8bhyuxvlVUwbeLOGynkunvlTMxchC5urrKndYiwCFC0DLVjpOCA==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  jest-each@29.7.0:
+    resolution: {integrity: sha512-gns+Er14+ZrEoC5fhOfYCY1LOHHr0TI+rQUHZS8Ttw2l7gl+80eHc/gFf2Ktkw0+SIACDTeWvpFcv3B04VembQ==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
   jest-each@30.2.0:
     resolution: {integrity: sha512-lpWlJlM7bCUf1mfmuqTA8+j2lNURW9eNafOy99knBM01i5CQeY5UH1vZjgT9071nDJac1M4XsbyI44oNOdhlDQ==}
@@ -8475,6 +8608,10 @@ packages:
     resolution: {integrity: sha512-POXfWAMvfU6WMUXftV4HolnJfnPOGEu10fscNCA76KBpRRhcMN2c8d3iT2pxQS3HLbA+5X4sOUPzYO2NUyIlHQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
 
+  jest-leak-detector@29.7.0:
+    resolution: {integrity: sha512-kYA8IJcSYtST2BY9I+SMC32nDpBT3J2NvWJx8+JCuCdl/CR1I4EKUJROiP8XtCcxqgTTBGJNdbB1A8XRKbTetw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
   jest-leak-detector@30.2.0:
     resolution: {integrity: sha512-M6jKAjyzjHG0SrQgwhgZGy9hFazcudwCNovY/9HPIicmNSBuockPSedAP9vlPK6ONFJ1zfyH/M2/YYJxOz5cdQ==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
@@ -8482,6 +8619,10 @@ packages:
   jest-matcher-utils@27.5.1:
     resolution: {integrity: sha512-z2uTx/T6LBaCoNWNFWwChLBKYxTMcGBRjAt+2SbP929/Fflb9aa5LGma654Rz8z9HLxsrUaYzxE9T/EFIL/PAw==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
+  jest-matcher-utils@29.7.0:
+    resolution: {integrity: sha512-sBkD+Xi9DtcChsI3L3u0+N0opgPYnCRPtGcQYrgXmR+hmt/fYfWAL0xRXYU8eWOdfuLgBe0YCW3AFtnRLagq/g==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
   jest-matcher-utils@30.1.2:
     resolution: {integrity: sha512-7ai16hy4rSbDjvPTuUhuV8nyPBd6EX34HkBsBcBX2lENCuAQ0qKCPb/+lt8OSWUa9WWmGYLy41PrEzkwRwoGZQ==}
@@ -8544,6 +8685,10 @@ packages:
     resolution: {integrity: sha512-jHEQgBXAgc+Gh4g0p3bCevgRCVRkB4VB70zhoAE48gxeSr1hfUOsM/C2WoJgVL7Eyg//hudYENbm3Ne+/dRVVA==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
+  jest-resolve-dependencies@29.7.0:
+    resolution: {integrity: sha512-un0zD/6qxJ+S0et7WxeI3H5XSe9lTBBR7bOHCHXkKR6luG5mwDDlIzVQ0V5cZCuoTgEdcdwzTghYkTWfubi+nA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
   jest-resolve-dependencies@30.2.0:
     resolution: {integrity: sha512-xTOIGug/0RmIe3mmCqCT95yO0vj6JURrn1TKWlNbhiAefJRWINNPgwVkrVgt/YaerPzY3iItufd80v3lOrFJ2w==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
@@ -8551,6 +8696,10 @@ packages:
   jest-resolve@27.5.1:
     resolution: {integrity: sha512-FFDy8/9E6CV83IMbDpcjOhumAQPDyETnU2KZ1O98DwTnz8AOBsW/Xv3GySr1mOZdItLR+zDZ7I/UdTFbgSOVCw==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
+  jest-resolve@29.7.0:
+    resolution: {integrity: sha512-IOVhZSrg+UvVAshDSDtHyFCCBUl/Q3AAJv8iZ6ZjnZ74xzvwuzLXid9IIIPgTnY62SJjfuupMKZsZQRsCvxEgA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
   jest-resolve@30.2.0:
     resolution: {integrity: sha512-TCrHSxPlx3tBY3hWNtRQKbtgLhsXa1WmbJEqBlTBrGafd5fiQFByy2GNCEoGR+Tns8d15GaL9cxEzKOO3GEb2A==}
@@ -8573,6 +8722,10 @@ packages:
     resolution: {integrity: sha512-g4NPsM4mFCOwFKXO4p/H/kWGdJp9V8kURY2lX8Me2drgXqG7rrZAx5kv+5H7wtt/cdFIjhqYx1HrlqWHaOvDaQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
 
+  jest-runner@29.7.0:
+    resolution: {integrity: sha512-fsc4N6cPCAahybGBfTRcq5wFR6fpLznMg47sY5aDpsoejOcVYFb07AHuSnR0liMcPTgBsA3ZJL6kFOjPdoNipQ==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
   jest-runner@30.2.0:
     resolution: {integrity: sha512-PqvZ2B2XEyPEbclp+gV6KO/F1FIFSbIwewRgmROCMBo/aZ6J1w8Qypoj2pEOcg3G2HzLlaP6VUtvwCI8dM3oqQ==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
@@ -8580,6 +8733,10 @@ packages:
   jest-runtime@27.5.1:
     resolution: {integrity: sha512-o7gxw3Gf+H2IGt8fv0RiyE1+r83FJBRruoA+FXrlHw6xEyBsU8ugA6IPfTdVyA0w8HClpbK+DGJxH59UrNMx8A==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
+  jest-runtime@29.7.0:
+    resolution: {integrity: sha512-gUnLjgwdGqW7B4LvOIkbKs9WGbn+QLqRQQ9juC6HndeDiezIwhDP+mhMwHWCEcfQ5RUXa6OPnFF8BJh5xegwwQ==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
   jest-runtime@30.2.0:
     resolution: {integrity: sha512-p1+GVX/PJqTucvsmERPMgCPvQJpFt4hFbM+VN3n8TMo47decMUcJbt+rgzwrEme0MQUA/R+1de2axftTHkKckg==}
@@ -8592,6 +8749,10 @@ packages:
   jest-snapshot@27.5.1:
     resolution: {integrity: sha512-yYykXI5a0I31xX67mgeLw1DZ0bJB+gpq5IpSuCAoyDi0+BhgU/RIrL+RTzDmkNTchvDFWKP8lp+w/42Z3us5sA==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
+  jest-snapshot@29.7.0:
+    resolution: {integrity: sha512-Rm0BMWtxBcioHr1/OX5YCP8Uov4riHvKPknOGs804Zg9JGZgmIBkbtlxJC/7Z4msKYVbIJtfU+tKb8xlYNfdkw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
   jest-snapshot@30.2.0:
     resolution: {integrity: sha512-5WEtTy2jXPFypadKNpbNkZ72puZCa6UjSr/7djeecHWOu7iYhSXSnHScT8wBz3Rn8Ena5d5RYRcsyKIeqG1IyA==}
@@ -8641,6 +8802,10 @@ packages:
     peerDependencies:
       jest: ^30.0.0
 
+  jest-watcher@29.7.0:
+    resolution: {integrity: sha512-49Fg7WXkU3Vl2h6LbLtMQ/HyB6rXSIX7SqvBLQmssRBGN9I0PNvPmAmCWSOY6SOvrjhI/F7/bGAv9RtnsPA03g==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
   jest-watcher@30.1.3:
     resolution: {integrity: sha512-6jQUZCP1BTL2gvG9E4YF06Ytq4yMb4If6YoQGRR6PpjtqOXSP3sKe2kqwB6SQ+H9DezOfZaSLnmka1NtGm3fCQ==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
@@ -8664,6 +8829,16 @@ packages:
   jest-worker@30.2.0:
     resolution: {integrity: sha512-0Q4Uk8WF7BUwqXHuAjc23vmopWJw5WH7w2tqBoUOZpOjW/ZnR44GXXd1r82RvnmI2GZge3ivrYXk/BE2+VtW2g==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  jest@29.7.0:
+    resolution: {integrity: sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    hasBin: true
+    peerDependencies:
+      node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
+    peerDependenciesMeta:
+      node-notifier:
+        optional: true
 
   jest@30.2.0:
     resolution: {integrity: sha512-F26gjC0yWN8uAA5m5Ss8ZQf5nDHWGlN/xWZIh8S5SRbsEKBovwZhxGd6LJlbZYxBgCYOtreSUyb8hpXyGC5O4A==}
@@ -9270,6 +9445,10 @@ packages:
   mimic-fn@2.1.0:
     resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
     engines: {node: '>=6'}
+
+  min-indent@1.0.1:
+    resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
+    engines: {node: '>=4'}
 
   miniflare@4.20260405.0:
     resolution: {integrity: sha512-tpr4XdWMq7zFdsHH+CS0XS47nQzlRZH0rMJ1vobOZbkrs3cIj7qbD40ON616hDnzHxwqwB2qKHzmmuj6oRisSQ==}
@@ -9891,6 +10070,9 @@ packages:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
+  pure-rand@6.1.0:
+    resolution: {integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==}
+
   pure-rand@7.0.1:
     resolution: {integrity: sha512-oTUZM/NAZS8p7ANR3SHh30kXB+zK2r2BPcEn/awJIbOvq82WoMN4p62AWWp3Hhw50G0xMsw1mhIBLqHw64EcNQ==}
 
@@ -10091,6 +10273,11 @@ packages:
       '@types/react':
         optional: true
 
+  react-test-renderer@19.2.0:
+    resolution: {integrity: sha512-zLCFMHFE9vy/w3AxO0zNxy6aAupnCuLSVOJYDe/Tp+ayGI1f2PLQsFVPANSD42gdSbmYx5oN+1VWDhcXtq7hAQ==}
+    peerDependencies:
+      react: ^19.2.0
+
   react-test-renderer@19.2.1:
     resolution: {integrity: sha512-xsyf515ij+d8Rs/tsDZSJYXn+GdYO/IOw9BVFtjJbrrFR+dL1yZQQN1ChxY6otYAsCeAHhU0XsKyJUzP6omyvQ==}
     peerDependencies:
@@ -10145,6 +10332,10 @@ packages:
 
   recma-stringify@1.0.0:
     resolution: {integrity: sha512-cjwII1MdIIVloKvC9ErQ+OgAtwHBmcZ0Bg4ciz78FtbT8In39aAYbaA7zvxQ61xVMSPE8WxhLwLbhif4Js2C+g==}
+
+  redent@3.0.0:
+    resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
+    engines: {node: '>=8'}
 
   reflect.getprototypeof@1.0.10:
     resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
@@ -10275,6 +10466,10 @@ packages:
 
   resolve.exports@1.1.1:
     resolution: {integrity: sha512-/NtpHNDN7jWhAaQ9BvBUYZ6YTXsRBgfqWFWP7BZBaoMJO/I3G5OFzvTuWNlZC3aPjins1F+TNrLKsGbH4rfsRQ==}
+    engines: {node: '>=10'}
+
+  resolve.exports@2.0.3:
+    resolution: {integrity: sha512-OcXjMsGdhL4XnbShKpAcSqPMzQoYkYyhbEaeSko47MjRP9NfEQMhZkXL1DoFlt9LWQn4YttrdnV6X2OiyzBi+A==}
     engines: {node: '>=10'}
 
   resolve@1.22.10:
@@ -10691,6 +10886,10 @@ packages:
   strip-final-newline@2.0.0:
     resolution: {integrity: sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==}
     engines: {node: '>=6'}
+
+  strip-indent@3.0.0:
+    resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
+    engines: {node: '>=8'}
 
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
@@ -12867,8 +13066,6 @@ snapshots:
       pirates: 4.0.7
       source-map-support: 0.5.21
 
-  '@babel/runtime@7.28.4': {}
-
   '@babel/runtime@7.28.6': {}
 
   '@babel/template@7.27.2':
@@ -13652,7 +13849,7 @@ snapshots:
       ws: 8.19.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
       zod: 3.25.76
     optionalDependencies:
-      expo-router: 55.0.8(6df5edb65d27401d90e5d77b2016246d)
+      expo-router: 55.0.8(68e2cb8634aa280894cf9251c9ce289f)
       react-native: 0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
       - '@expo/dom-webview'
@@ -13912,7 +14109,7 @@ snapshots:
       react: 19.2.0
     optionalDependencies:
       '@expo/metro-runtime': 6.1.2(expo@55.0.9)(react-dom@19.2.0(react@19.2.0))(react-native@0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)
-      expo-router: 55.0.8(6df5edb65d27401d90e5d77b2016246d)
+      expo-router: 55.0.8(68e2cb8634aa280894cf9251c9ce289f)
       react-dom: 19.2.0(react@19.2.0)
     transitivePeerDependencies:
       - supports-color
@@ -14162,6 +14359,15 @@ snapshots:
       jest-util: 27.5.1
       slash: 3.0.0
 
+  '@jest/console@29.7.0':
+    dependencies:
+      '@jest/types': 29.6.3
+      '@types/node': 24.10.1
+      chalk: 4.1.2
+      jest-message-util: 29.7.0
+      jest-util: 29.7.0
+      slash: 3.0.0
+
   '@jest/console@30.1.2':
     dependencies:
       '@jest/types': 30.0.5
@@ -14179,6 +14385,76 @@ snapshots:
       jest-message-util: 30.2.0
       jest-util: 30.2.0
       slash: 3.0.0
+
+  '@jest/core@29.7.0(ts-node@10.9.2(@swc/core@1.13.5(@swc/helpers@0.5.18))(@types/node@24.10.1)(typescript@6.0.2))':
+    dependencies:
+      '@jest/console': 29.7.0
+      '@jest/reporters': 29.7.0
+      '@jest/test-result': 29.7.0
+      '@jest/transform': 29.7.0
+      '@jest/types': 29.6.3
+      '@types/node': 24.10.1
+      ansi-escapes: 4.3.2
+      chalk: 4.1.2
+      ci-info: 3.9.0
+      exit: 0.1.2
+      graceful-fs: 4.2.11
+      jest-changed-files: 29.7.0
+      jest-config: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@swc/core@1.13.5(@swc/helpers@0.5.18))(@types/node@24.10.1)(typescript@6.0.2))
+      jest-haste-map: 29.7.0
+      jest-message-util: 29.7.0
+      jest-regex-util: 29.6.3
+      jest-resolve: 29.7.0
+      jest-resolve-dependencies: 29.7.0
+      jest-runner: 29.7.0
+      jest-runtime: 29.7.0
+      jest-snapshot: 29.7.0
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      jest-watcher: 29.7.0
+      micromatch: 4.0.8
+      pretty-format: 29.7.0
+      slash: 3.0.0
+      strip-ansi: 6.0.1
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
+
+  '@jest/core@29.7.0(ts-node@10.9.2(@swc/core@1.13.5(@swc/helpers@0.5.18))(@types/node@25.3.1)(typescript@6.0.2))':
+    dependencies:
+      '@jest/console': 29.7.0
+      '@jest/reporters': 29.7.0
+      '@jest/test-result': 29.7.0
+      '@jest/transform': 29.7.0
+      '@jest/types': 29.6.3
+      '@types/node': 24.10.1
+      ansi-escapes: 4.3.2
+      chalk: 4.1.2
+      ci-info: 3.9.0
+      exit: 0.1.2
+      graceful-fs: 4.2.11
+      jest-changed-files: 29.7.0
+      jest-config: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@swc/core@1.13.5(@swc/helpers@0.5.18))(@types/node@25.3.1)(typescript@6.0.2))
+      jest-haste-map: 29.7.0
+      jest-message-util: 29.7.0
+      jest-regex-util: 29.6.3
+      jest-resolve: 29.7.0
+      jest-resolve-dependencies: 29.7.0
+      jest-runner: 29.7.0
+      jest-runtime: 29.7.0
+      jest-snapshot: 29.7.0
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      jest-watcher: 29.7.0
+      micromatch: 4.0.8
+      pretty-format: 29.7.0
+      slash: 3.0.0
+      strip-ansi: 6.0.1
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
 
   '@jest/core@30.2.0(ts-node@10.9.2(@swc/core@1.13.5(@swc/helpers@0.5.18))(@types/node@24.5.2)(typescript@6.0.2))':
     dependencies:
@@ -14258,6 +14534,10 @@ snapshots:
       '@types/node': 24.10.1
       jest-mock: 30.2.0
 
+  '@jest/expect-utils@29.7.0':
+    dependencies:
+      jest-get-type: 29.6.3
+
   '@jest/expect-utils@30.1.2':
     dependencies:
       '@jest/get-type': 30.1.0
@@ -14265,6 +14545,13 @@ snapshots:
   '@jest/expect-utils@30.2.0':
     dependencies:
       '@jest/get-type': 30.1.0
+
+  '@jest/expect@29.7.0':
+    dependencies:
+      expect: 29.7.0
+      jest-snapshot: 29.7.0
+    transitivePeerDependencies:
+      - supports-color
 
   '@jest/expect@30.2.0':
     dependencies:
@@ -14308,6 +14595,15 @@ snapshots:
       '@jest/types': 27.5.1
       expect: 27.5.1
 
+  '@jest/globals@29.7.0':
+    dependencies:
+      '@jest/environment': 29.7.0
+      '@jest/expect': 29.7.0
+      '@jest/types': 29.6.3
+      jest-mock: 29.7.0
+    transitivePeerDependencies:
+      - supports-color
+
   '@jest/globals@30.2.0':
     dependencies:
       '@jest/environment': 30.2.0
@@ -14321,6 +14617,35 @@ snapshots:
     dependencies:
       '@types/node': 24.10.1
       jest-regex-util: 30.0.1
+
+  '@jest/reporters@29.7.0':
+    dependencies:
+      '@bcoe/v8-coverage': 0.2.3
+      '@jest/console': 29.7.0
+      '@jest/test-result': 29.7.0
+      '@jest/transform': 29.7.0
+      '@jest/types': 29.6.3
+      '@jridgewell/trace-mapping': 0.3.31
+      '@types/node': 24.10.1
+      chalk: 4.1.2
+      collect-v8-coverage: 1.0.2
+      exit: 0.1.2
+      glob: 7.2.3
+      graceful-fs: 4.2.11
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-instrument: 6.0.3
+      istanbul-lib-report: 3.0.1
+      istanbul-lib-source-maps: 4.0.1
+      istanbul-reports: 3.2.0
+      jest-message-util: 29.7.0
+      jest-util: 29.7.0
+      jest-worker: 29.7.0
+      slash: 3.0.0
+      string-length: 4.0.2
+      strip-ansi: 6.0.1
+      v8-to-istanbul: 9.3.0
+    transitivePeerDependencies:
+      - supports-color
 
   '@jest/reporters@30.2.0':
     dependencies:
@@ -14371,6 +14696,12 @@ snapshots:
       graceful-fs: 4.2.11
       source-map: 0.6.1
 
+  '@jest/source-map@29.6.3':
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      callsites: 3.1.0
+      graceful-fs: 4.2.11
+
   '@jest/source-map@30.0.1':
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
@@ -14381,6 +14712,13 @@ snapshots:
     dependencies:
       '@jest/console': 27.5.1
       '@jest/types': 27.5.1
+      '@types/istanbul-lib-coverage': 2.0.6
+      collect-v8-coverage: 1.0.2
+
+  '@jest/test-result@29.7.0':
+    dependencies:
+      '@jest/console': 29.7.0
+      '@jest/types': 29.6.3
       '@types/istanbul-lib-coverage': 2.0.6
       collect-v8-coverage: 1.0.2
 
@@ -14397,6 +14735,13 @@ snapshots:
       '@jest/types': 30.2.0
       '@types/istanbul-lib-coverage': 2.0.6
       collect-v8-coverage: 1.0.2
+
+  '@jest/test-sequencer@29.7.0':
+    dependencies:
+      '@jest/test-result': 29.7.0
+      graceful-fs: 4.2.11
+      jest-haste-map: 29.7.0
+      slash: 3.0.0
 
   '@jest/test-sequencer@30.2.0':
     dependencies:
@@ -17270,7 +17615,7 @@ snapshots:
 
   '@solana/web3.js@1.98.4(bufferutil@4.0.9)(typescript@6.0.2)(utf-8-validate@5.0.10)':
     dependencies:
-      '@babel/runtime': 7.28.4
+      '@babel/runtime': 7.28.6
       '@noble/curves': 1.9.7
       '@noble/hashes': 1.8.0
       '@solana/buffer-layout': 4.0.1
@@ -17472,6 +17817,32 @@ snapshots:
     dependencies:
       '@tanstack/query-core': 5.90.7
       react: 19.2.0
+
+  '@testing-library/react-native@13.3.3(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@swc/core@1.13.5(@swc/helpers@0.5.18))(@types/node@24.10.1)(typescript@6.0.2)))(react-native@0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react-test-renderer@19.2.0(react@19.2.0))(react@19.2.0)':
+    dependencies:
+      jest-matcher-utils: 30.2.0
+      picocolors: 1.1.1
+      pretty-format: 30.2.0
+      react: 19.2.0
+      react-native: 0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10)
+      react-test-renderer: 19.2.0(react@19.2.0)
+      redent: 3.0.0
+    optionalDependencies:
+      jest: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@swc/core@1.13.5(@swc/helpers@0.5.18))(@types/node@24.10.1)(typescript@6.0.2))
+    optional: true
+
+  '@testing-library/react-native@13.3.3(jest@29.7.0(@types/node@25.3.1)(ts-node@10.9.2(@swc/core@1.13.5(@swc/helpers@0.5.18))(@types/node@25.3.1)(typescript@6.0.2)))(react-native@0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react-test-renderer@19.2.0(react@19.2.0))(react@19.2.0)':
+    dependencies:
+      jest-matcher-utils: 30.2.0
+      picocolors: 1.1.1
+      pretty-format: 30.2.0
+      react: 19.2.0
+      react-native: 0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10)
+      react-test-renderer: 19.2.0(react@19.2.0)
+      redent: 3.0.0
+    optionalDependencies:
+      jest: 29.7.0(@types/node@25.3.1)(ts-node@10.9.2(@swc/core@1.13.5(@swc/helpers@0.5.18))(@types/node@25.3.1)(typescript@6.0.2))
+    optional: true
 
   '@tootallnate/once@2.0.0': {}
 
@@ -18926,7 +19297,7 @@ snapshots:
 
   baseline-browser-mapping@2.10.13: {}
 
-  baseline-browser-mapping@2.10.16: {}
+  baseline-browser-mapping@2.10.17: {}
 
   baseline-browser-mapping@2.9.2: {}
 
@@ -19008,7 +19379,7 @@ snapshots:
 
   browserslist@4.28.2:
     dependencies:
-      baseline-browser-mapping: 2.10.16
+      baseline-browser-mapping: 2.10.17
       caniuse-lite: 1.0.30001787
       electron-to-chromium: 1.5.334
       node-releases: 2.0.37
@@ -19327,6 +19698,36 @@ snapshots:
       jest-worker: 27.5.1
       throat: 6.0.2
 
+  create-jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@swc/core@1.13.5(@swc/helpers@0.5.18))(@types/node@24.10.1)(typescript@6.0.2)):
+    dependencies:
+      '@jest/types': 29.6.3
+      chalk: 4.1.2
+      exit: 0.1.2
+      graceful-fs: 4.2.11
+      jest-config: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@swc/core@1.13.5(@swc/helpers@0.5.18))(@types/node@24.10.1)(typescript@6.0.2))
+      jest-util: 29.7.0
+      prompts: 2.4.2
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
+
+  create-jest@29.7.0(@types/node@25.3.1)(ts-node@10.9.2(@swc/core@1.13.5(@swc/helpers@0.5.18))(@types/node@25.3.1)(typescript@6.0.2)):
+    dependencies:
+      '@jest/types': 29.6.3
+      chalk: 4.1.2
+      exit: 0.1.2
+      graceful-fs: 4.2.11
+      jest-config: 29.7.0(@types/node@25.3.1)(ts-node@10.9.2(@swc/core@1.13.5(@swc/helpers@0.5.18))(@types/node@25.3.1)(typescript@6.0.2))
+      jest-util: 29.7.0
+      prompts: 2.4.2
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
+
   create-require@1.1.1: {}
 
   cross-fetch@3.2.0:
@@ -19499,6 +19900,8 @@ snapshots:
       dequal: 2.0.3
 
   diff-sequences@27.5.1: {}
+
+  diff-sequences@29.6.3: {}
 
   diff@4.0.2: {}
 
@@ -20433,6 +20836,8 @@ snapshots:
 
   exit-x@0.2.2: {}
 
+  exit@0.1.2: {}
+
   expand-tilde@1.2.2:
     dependencies:
       os-homedir: 1.0.2
@@ -20443,6 +20848,14 @@ snapshots:
       jest-get-type: 27.5.1
       jest-matcher-utils: 27.5.1
       jest-message-util: 27.5.1
+
+  expect@29.7.0:
+    dependencies:
+      '@jest/expect-utils': 29.7.0
+      jest-get-type: 29.6.3
+      jest-matcher-utils: 29.7.0
+      jest-message-util: 29.7.0
+      jest-util: 29.7.0
 
   expect@30.1.2:
     dependencies:
@@ -20588,7 +21001,7 @@ snapshots:
       react: 19.2.0
       react-native: 0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10)
 
-  expo-router@55.0.8(6df5edb65d27401d90e5d77b2016246d):
+  expo-router@55.0.8(3326c468d016b2779095fe21d9c3c8f2):
     dependencies:
       '@expo/log-box': 55.0.8(@expo/dom-webview@55.0.3)(expo@55.0.9)(react-native@0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)
       '@expo/metro-runtime': 6.1.2(expo@55.0.9)(react-dom@19.2.0(react@19.2.0))(react-native@0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)
@@ -20625,6 +21038,56 @@ snapshots:
       use-latest-callback: 0.2.6(react@19.2.0)
       vaul: 1.1.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
     optionalDependencies:
+      '@testing-library/react-native': 13.3.3(jest@29.7.0(@types/node@25.3.1)(ts-node@10.9.2(@swc/core@1.13.5(@swc/helpers@0.5.18))(@types/node@25.3.1)(typescript@6.0.2)))(react-native@0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react-test-renderer@19.2.0(react@19.2.0))(react@19.2.0)
+      react-dom: 19.2.0(react@19.2.0)
+      react-native-gesture-handler: 2.30.1(react-native@0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)
+      react-native-reanimated: 4.2.1(react-native-worklets@0.7.2(@babel/core@7.29.0)(react-native@0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0))(react-native@0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)
+      react-native-web: 0.21.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+    transitivePeerDependencies:
+      - '@react-native-masked-view/masked-view'
+      - '@types/react'
+      - '@types/react-dom'
+      - expo-font
+      - supports-color
+
+  expo-router@55.0.8(68e2cb8634aa280894cf9251c9ce289f):
+    dependencies:
+      '@expo/log-box': 55.0.8(@expo/dom-webview@55.0.3)(expo@55.0.9)(react-native@0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)
+      '@expo/metro-runtime': 6.1.2(expo@55.0.9)(react-dom@19.2.0(react@19.2.0))(react-native@0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)
+      '@expo/schema-utils': 55.0.2
+      '@radix-ui/react-slot': 1.2.4(@types/react@19.2.14)(react@19.2.0)
+      '@radix-ui/react-tabs': 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@react-navigation/bottom-tabs': 7.15.9(@react-navigation/native@7.2.2(react-native@0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0))(react-native-safe-area-context@5.6.2(react-native@0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0))(react-native-screens@4.23.0(react-native@0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0))(react-native@0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)
+      '@react-navigation/native': 7.2.2(react-native@0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)
+      '@react-navigation/native-stack': 7.14.10(@react-navigation/native@7.2.2(react-native@0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0))(react-native-safe-area-context@5.6.2(react-native@0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0))(react-native-screens@4.23.0(react-native@0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0))(react-native@0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)
+      client-only: 0.0.1
+      debug: 4.4.3
+      escape-string-regexp: 4.0.0
+      expo: 55.0.9(@babel/core@7.29.0)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@6.1.2)(bufferutil@4.0.9)(expo-router@55.0.8)(react-dom@19.2.0(react@19.2.0))(react-native@0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)(typescript@6.0.2)(utf-8-validate@5.0.10)
+      expo-constants: 55.0.9(expo@55.0.9)(react-native@0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(typescript@6.0.2)
+      expo-glass-effect: 55.0.8(expo@55.0.9)(react-native@0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)
+      expo-image: 55.0.6(expo@55.0.9)(react-native-web@0.21.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-native@0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)
+      expo-linking: 55.0.9(expo@55.0.9)(react-native@0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)(typescript@6.0.2)
+      expo-server: 55.0.6
+      expo-symbols: 55.0.5(expo-font@55.0.4)(expo@55.0.9)(react-native@0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)
+      fast-deep-equal: 3.1.3
+      invariant: 2.2.4
+      nanoid: 3.3.11
+      query-string: 7.1.3
+      react: 19.2.0
+      react-fast-compare: 3.2.2
+      react-native: 0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10)
+      react-native-is-edge-to-edge: 1.2.1(react-native@0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)
+      react-native-safe-area-context: 5.6.2(react-native@0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)
+      react-native-screens: 4.23.0(react-native@0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)
+      semver: 7.6.3
+      server-only: 0.0.1
+      sf-symbols-typescript: 2.1.0
+      shallowequal: 1.1.0
+      use-latest-callback: 0.2.6(react@19.2.0)
+      vaul: 1.1.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+    optionalDependencies:
+      '@testing-library/react-native': 13.3.3(jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@swc/core@1.13.5(@swc/helpers@0.5.18))(@types/node@24.10.1)(typescript@6.0.2)))(react-native@0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react-test-renderer@19.2.0(react@19.2.0))(react@19.2.0)
       react-dom: 19.2.0(react@19.2.0)
       react-native-gesture-handler: 2.30.1(react-native@0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)
       react-native-reanimated: 4.2.1(react-native-worklets@0.7.2(@babel/core@7.29.0)(react-native@0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0))(react-native@0.83.4(@babel/core@7.29.0)(@types/react@19.2.14)(bufferutil@4.0.9)(react@19.2.0)(utf-8-validate@5.0.10))(react@19.2.0)
@@ -21431,6 +21894,9 @@ snapshots:
 
   imurmurhash@0.1.4: {}
 
+  indent-string@4.0.0:
+    optional: true
+
   inflight@1.0.6:
     dependencies:
       once: 1.4.0
@@ -21674,6 +22140,14 @@ snapshots:
       make-dir: 4.0.0
       supports-color: 7.2.0
 
+  istanbul-lib-source-maps@4.0.1:
+    dependencies:
+      debug: 4.4.3
+      istanbul-lib-coverage: 3.2.2
+      source-map: 0.6.1
+    transitivePeerDependencies:
+      - supports-color
+
   istanbul-lib-source-maps@5.0.6:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
@@ -21720,11 +22194,43 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
+  jest-changed-files@29.7.0:
+    dependencies:
+      execa: 5.1.1
+      jest-util: 29.7.0
+      p-limit: 3.1.0
+
   jest-changed-files@30.2.0:
     dependencies:
       execa: 5.1.1
       jest-util: 30.2.0
       p-limit: 3.1.0
+
+  jest-circus@29.7.0:
+    dependencies:
+      '@jest/environment': 29.7.0
+      '@jest/expect': 29.7.0
+      '@jest/test-result': 29.7.0
+      '@jest/types': 29.6.3
+      '@types/node': 24.10.1
+      chalk: 4.1.2
+      co: 4.6.0
+      dedent: 1.7.0
+      is-generator-fn: 2.1.0
+      jest-each: 29.7.0
+      jest-matcher-utils: 29.7.0
+      jest-message-util: 29.7.0
+      jest-runtime: 29.7.0
+      jest-snapshot: 29.7.0
+      jest-util: 29.7.0
+      p-limit: 3.1.0
+      pretty-format: 29.7.0
+      pure-rand: 6.1.0
+      slash: 3.0.0
+      stack-utils: 2.0.6
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
 
   jest-circus@30.2.0:
     dependencies:
@@ -21752,6 +22258,44 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
+  jest-cli@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@swc/core@1.13.5(@swc/helpers@0.5.18))(@types/node@24.10.1)(typescript@6.0.2)):
+    dependencies:
+      '@jest/core': 29.7.0(ts-node@10.9.2(@swc/core@1.13.5(@swc/helpers@0.5.18))(@types/node@24.10.1)(typescript@6.0.2))
+      '@jest/test-result': 29.7.0
+      '@jest/types': 29.6.3
+      chalk: 4.1.2
+      create-jest: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@swc/core@1.13.5(@swc/helpers@0.5.18))(@types/node@24.10.1)(typescript@6.0.2))
+      exit: 0.1.2
+      import-local: 3.2.0
+      jest-config: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@swc/core@1.13.5(@swc/helpers@0.5.18))(@types/node@24.10.1)(typescript@6.0.2))
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
+
+  jest-cli@29.7.0(@types/node@25.3.1)(ts-node@10.9.2(@swc/core@1.13.5(@swc/helpers@0.5.18))(@types/node@25.3.1)(typescript@6.0.2)):
+    dependencies:
+      '@jest/core': 29.7.0(ts-node@10.9.2(@swc/core@1.13.5(@swc/helpers@0.5.18))(@types/node@25.3.1)(typescript@6.0.2))
+      '@jest/test-result': 29.7.0
+      '@jest/types': 29.6.3
+      chalk: 4.1.2
+      create-jest: 29.7.0(@types/node@25.3.1)(ts-node@10.9.2(@swc/core@1.13.5(@swc/helpers@0.5.18))(@types/node@25.3.1)(typescript@6.0.2))
+      exit: 0.1.2
+      import-local: 3.2.0
+      jest-config: 29.7.0(@types/node@25.3.1)(ts-node@10.9.2(@swc/core@1.13.5(@swc/helpers@0.5.18))(@types/node@25.3.1)(typescript@6.0.2))
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
+
   jest-cli@30.2.0(@types/node@24.5.2)(ts-node@10.9.2(@swc/core@1.13.5(@swc/helpers@0.5.18))(@types/node@24.5.2)(typescript@6.0.2)):
     dependencies:
       '@jest/core': 30.2.0(ts-node@10.9.2(@swc/core@1.13.5(@swc/helpers@0.5.18))(@types/node@24.5.2)(typescript@6.0.2))
@@ -21770,6 +22314,99 @@ snapshots:
       - esbuild-register
       - supports-color
       - ts-node
+
+  jest-config@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@swc/core@1.13.5(@swc/helpers@0.5.18))(@types/node@24.10.1)(typescript@6.0.2)):
+    dependencies:
+      '@babel/core': 7.29.0
+      '@jest/test-sequencer': 29.7.0
+      '@jest/types': 29.6.3
+      babel-jest: 29.7.0(@babel/core@7.29.0)
+      chalk: 4.1.2
+      ci-info: 3.9.0
+      deepmerge: 4.3.1
+      glob: 7.2.3
+      graceful-fs: 4.2.11
+      jest-circus: 29.7.0
+      jest-environment-node: 29.7.0
+      jest-get-type: 29.6.3
+      jest-regex-util: 29.6.3
+      jest-resolve: 29.7.0
+      jest-runner: 29.7.0
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      micromatch: 4.0.8
+      parse-json: 5.2.0
+      pretty-format: 29.7.0
+      slash: 3.0.0
+      strip-json-comments: 3.1.1
+    optionalDependencies:
+      '@types/node': 24.10.1
+      ts-node: 10.9.2(@swc/core@1.13.5(@swc/helpers@0.5.18))(@types/node@24.10.1)(typescript@6.0.2)
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+
+  jest-config@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@swc/core@1.13.5(@swc/helpers@0.5.18))(@types/node@25.3.1)(typescript@6.0.2)):
+    dependencies:
+      '@babel/core': 7.29.0
+      '@jest/test-sequencer': 29.7.0
+      '@jest/types': 29.6.3
+      babel-jest: 29.7.0(@babel/core@7.29.0)
+      chalk: 4.1.2
+      ci-info: 3.9.0
+      deepmerge: 4.3.1
+      glob: 7.2.3
+      graceful-fs: 4.2.11
+      jest-circus: 29.7.0
+      jest-environment-node: 29.7.0
+      jest-get-type: 29.6.3
+      jest-regex-util: 29.6.3
+      jest-resolve: 29.7.0
+      jest-runner: 29.7.0
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      micromatch: 4.0.8
+      parse-json: 5.2.0
+      pretty-format: 29.7.0
+      slash: 3.0.0
+      strip-json-comments: 3.1.1
+    optionalDependencies:
+      '@types/node': 24.10.1
+      ts-node: 10.9.2(@swc/core@1.13.5(@swc/helpers@0.5.18))(@types/node@25.3.1)(typescript@6.0.2)
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+
+  jest-config@29.7.0(@types/node@25.3.1)(ts-node@10.9.2(@swc/core@1.13.5(@swc/helpers@0.5.18))(@types/node@25.3.1)(typescript@6.0.2)):
+    dependencies:
+      '@babel/core': 7.29.0
+      '@jest/test-sequencer': 29.7.0
+      '@jest/types': 29.6.3
+      babel-jest: 29.7.0(@babel/core@7.29.0)
+      chalk: 4.1.2
+      ci-info: 3.9.0
+      deepmerge: 4.3.1
+      glob: 7.2.3
+      graceful-fs: 4.2.11
+      jest-circus: 29.7.0
+      jest-environment-node: 29.7.0
+      jest-get-type: 29.6.3
+      jest-regex-util: 29.6.3
+      jest-resolve: 29.7.0
+      jest-runner: 29.7.0
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      micromatch: 4.0.8
+      parse-json: 5.2.0
+      pretty-format: 29.7.0
+      slash: 3.0.0
+      strip-json-comments: 3.1.1
+    optionalDependencies:
+      '@types/node': 25.3.1
+      ts-node: 10.9.2(@swc/core@1.13.5(@swc/helpers@0.5.18))(@types/node@25.3.1)(typescript@6.0.2)
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
 
   jest-config@30.2.0(@types/node@24.10.1)(ts-node@10.9.2(@swc/core@1.13.5(@swc/helpers@0.5.18))(@types/node@24.5.2)(typescript@6.0.2)):
     dependencies:
@@ -21856,6 +22493,13 @@ snapshots:
       jest-get-type: 27.5.1
       pretty-format: 27.5.1
 
+  jest-diff@29.7.0:
+    dependencies:
+      chalk: 4.1.2
+      diff-sequences: 29.6.3
+      jest-get-type: 29.6.3
+      pretty-format: 29.7.0
+
   jest-diff@30.1.2:
     dependencies:
       '@jest/diff-sequences': 30.0.1
@@ -21874,9 +22518,21 @@ snapshots:
     dependencies:
       detect-newline: 3.1.0
 
+  jest-docblock@29.7.0:
+    dependencies:
+      detect-newline: 3.1.0
+
   jest-docblock@30.2.0:
     dependencies:
       detect-newline: 3.1.0
+
+  jest-each@29.7.0:
+    dependencies:
+      '@jest/types': 29.6.3
+      chalk: 4.1.2
+      jest-get-type: 29.6.3
+      jest-util: 29.7.0
+      pretty-format: 29.7.0
 
   jest-each@30.2.0:
     dependencies:
@@ -21998,6 +22654,11 @@ snapshots:
       jest-get-type: 27.5.1
       pretty-format: 27.5.1
 
+  jest-leak-detector@29.7.0:
+    dependencies:
+      jest-get-type: 29.6.3
+      pretty-format: 29.7.0
+
   jest-leak-detector@30.2.0:
     dependencies:
       '@jest/get-type': 30.1.0
@@ -22009,6 +22670,13 @@ snapshots:
       jest-diff: 27.5.1
       jest-get-type: 27.5.1
       pretty-format: 27.5.1
+
+  jest-matcher-utils@29.7.0:
+    dependencies:
+      chalk: 4.1.2
+      jest-diff: 29.7.0
+      jest-get-type: 29.6.3
+      pretty-format: 29.7.0
 
   jest-matcher-utils@30.1.2:
     dependencies:
@@ -22099,6 +22767,10 @@ snapshots:
     optionalDependencies:
       jest-resolve: 27.5.1
 
+  jest-pnp-resolver@1.2.3(jest-resolve@29.7.0):
+    optionalDependencies:
+      jest-resolve: 29.7.0
+
   jest-pnp-resolver@1.2.3(jest-resolve@30.2.0):
     optionalDependencies:
       jest-resolve: 30.2.0
@@ -22108,6 +22780,13 @@ snapshots:
   jest-regex-util@29.6.3: {}
 
   jest-regex-util@30.0.1: {}
+
+  jest-resolve-dependencies@29.7.0:
+    dependencies:
+      jest-regex-util: 29.6.3
+      jest-snapshot: 29.7.0
+    transitivePeerDependencies:
+      - supports-color
 
   jest-resolve-dependencies@30.2.0:
     dependencies:
@@ -22127,6 +22806,18 @@ snapshots:
       jest-validate: 27.5.1
       resolve: 1.22.10
       resolve.exports: 1.1.1
+      slash: 3.0.0
+
+  jest-resolve@29.7.0:
+    dependencies:
+      chalk: 4.1.2
+      graceful-fs: 4.2.11
+      jest-haste-map: 29.7.0
+      jest-pnp-resolver: 1.2.3(jest-resolve@29.7.0)
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      resolve: 1.22.10
+      resolve.exports: 2.0.3
       slash: 3.0.0
 
   jest-resolve@30.2.0:
@@ -22196,6 +22887,32 @@ snapshots:
       - supports-color
       - utf-8-validate
 
+  jest-runner@29.7.0:
+    dependencies:
+      '@jest/console': 29.7.0
+      '@jest/environment': 29.7.0
+      '@jest/test-result': 29.7.0
+      '@jest/transform': 29.7.0
+      '@jest/types': 29.6.3
+      '@types/node': 24.10.1
+      chalk: 4.1.2
+      emittery: 0.13.1
+      graceful-fs: 4.2.11
+      jest-docblock: 29.7.0
+      jest-environment-node: 29.7.0
+      jest-haste-map: 29.7.0
+      jest-leak-detector: 29.7.0
+      jest-message-util: 29.7.0
+      jest-resolve: 29.7.0
+      jest-runtime: 29.7.0
+      jest-util: 29.7.0
+      jest-watcher: 29.7.0
+      jest-worker: 29.7.0
+      p-limit: 3.1.0
+      source-map-support: 0.5.13
+    transitivePeerDependencies:
+      - supports-color
+
   jest-runner@30.2.0:
     dependencies:
       '@jest/console': 30.2.0
@@ -22245,6 +22962,33 @@ snapshots:
       jest-resolve: 27.5.1
       jest-snapshot: 27.5.1
       jest-util: 27.5.1
+      slash: 3.0.0
+      strip-bom: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  jest-runtime@29.7.0:
+    dependencies:
+      '@jest/environment': 29.7.0
+      '@jest/fake-timers': 29.7.0
+      '@jest/globals': 29.7.0
+      '@jest/source-map': 29.6.3
+      '@jest/test-result': 29.7.0
+      '@jest/transform': 29.7.0
+      '@jest/types': 29.6.3
+      '@types/node': 24.10.1
+      chalk: 4.1.2
+      cjs-module-lexer: 1.4.3
+      collect-v8-coverage: 1.0.2
+      glob: 7.2.3
+      graceful-fs: 4.2.11
+      jest-haste-map: 29.7.0
+      jest-message-util: 29.7.0
+      jest-mock: 29.7.0
+      jest-regex-util: 29.6.3
+      jest-resolve: 29.7.0
+      jest-snapshot: 29.7.0
+      jest-util: 29.7.0
       slash: 3.0.0
       strip-bom: 4.0.0
     transitivePeerDependencies:
@@ -22305,6 +23049,31 @@ snapshots:
       jest-util: 27.5.1
       natural-compare: 1.4.0
       pretty-format: 27.5.1
+      semver: 7.7.4
+    transitivePeerDependencies:
+      - supports-color
+
+  jest-snapshot@29.7.0:
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/generator': 7.29.1
+      '@babel/plugin-syntax-jsx': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-syntax-typescript': 7.27.1(@babel/core@7.29.0)
+      '@babel/types': 7.29.0
+      '@jest/expect-utils': 29.7.0
+      '@jest/transform': 29.7.0
+      '@jest/types': 29.6.3
+      babel-preset-current-node-syntax: 1.2.0(@babel/core@7.29.0)
+      chalk: 4.1.2
+      expect: 29.7.0
+      graceful-fs: 4.2.11
+      jest-diff: 29.7.0
+      jest-get-type: 29.6.3
+      jest-matcher-utils: 29.7.0
+      jest-message-util: 29.7.0
+      jest-util: 29.7.0
+      natural-compare: 1.4.0
+      pretty-format: 29.7.0
       semver: 7.7.4
     transitivePeerDependencies:
       - supports-color
@@ -22421,6 +23190,17 @@ snapshots:
       string-length: 6.0.0
       strip-ansi: 7.1.2
 
+  jest-watcher@29.7.0:
+    dependencies:
+      '@jest/test-result': 29.7.0
+      '@jest/types': 29.6.3
+      '@types/node': 24.10.1
+      ansi-escapes: 4.3.2
+      chalk: 4.1.2
+      emittery: 0.13.1
+      jest-util: 29.7.0
+      string-length: 4.0.2
+
   jest-watcher@30.1.3:
     dependencies:
       '@jest/test-result': 30.1.3
@@ -22469,6 +23249,30 @@ snapshots:
       jest-util: 30.2.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
+
+  jest@29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@swc/core@1.13.5(@swc/helpers@0.5.18))(@types/node@24.10.1)(typescript@6.0.2)):
+    dependencies:
+      '@jest/core': 29.7.0(ts-node@10.9.2(@swc/core@1.13.5(@swc/helpers@0.5.18))(@types/node@24.10.1)(typescript@6.0.2))
+      '@jest/types': 29.6.3
+      import-local: 3.2.0
+      jest-cli: 29.7.0(@types/node@24.10.1)(ts-node@10.9.2(@swc/core@1.13.5(@swc/helpers@0.5.18))(@types/node@24.10.1)(typescript@6.0.2))
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
+
+  jest@29.7.0(@types/node@25.3.1)(ts-node@10.9.2(@swc/core@1.13.5(@swc/helpers@0.5.18))(@types/node@25.3.1)(typescript@6.0.2)):
+    dependencies:
+      '@jest/core': 29.7.0(ts-node@10.9.2(@swc/core@1.13.5(@swc/helpers@0.5.18))(@types/node@25.3.1)(typescript@6.0.2))
+      '@jest/types': 29.6.3
+      import-local: 3.2.0
+      jest-cli: 29.7.0(@types/node@25.3.1)(ts-node@10.9.2(@swc/core@1.13.5(@swc/helpers@0.5.18))(@types/node@25.3.1)(typescript@6.0.2))
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
 
   jest@30.2.0(@types/node@24.5.2)(ts-node@10.9.2(@swc/core@1.13.5(@swc/helpers@0.5.18))(@types/node@24.5.2)(typescript@6.0.2)):
     dependencies:
@@ -23446,6 +24250,9 @@ snapshots:
 
   mimic-fn@2.1.0: {}
 
+  min-indent@1.0.1:
+    optional: true
+
   miniflare@4.20260405.0(bufferutil@4.0.9)(utf-8-validate@5.0.10):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
@@ -24073,6 +24880,8 @@ snapshots:
 
   punycode@2.3.1: {}
 
+  pure-rand@6.1.0: {}
+
   pure-rand@7.0.1: {}
 
   quansync@0.2.11: {}
@@ -24140,12 +24949,12 @@ snapshots:
 
   react-error-boundary@6.0.0(react@19.1.0):
     dependencies:
-      '@babel/runtime': 7.28.4
+      '@babel/runtime': 7.28.6
       react: 19.1.0
 
   react-error-boundary@6.0.0(react@19.2.1):
     dependencies:
-      '@babel/runtime': 7.28.4
+      '@babel/runtime': 7.28.6
       react: 19.2.1
 
   react-fast-compare@3.2.2: {}
@@ -24220,7 +25029,7 @@ snapshots:
 
   react-native-web@0.21.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
     dependencies:
-      '@babel/runtime': 7.28.4
+      '@babel/runtime': 7.28.6
       '@react-native/normalize-colors': 0.74.89
       fbjs: 3.0.5
       inline-style-prefixer: 7.0.1
@@ -24462,6 +25271,12 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.7
 
+  react-test-renderer@19.2.0(react@19.2.0):
+    dependencies:
+      react: 19.2.0
+      react-is: 19.2.1
+      scheduler: 0.27.0
+
   react-test-renderer@19.2.1(react@19.1.0):
     dependencies:
       react: 19.1.0
@@ -24537,6 +25352,12 @@ snapshots:
       estree-util-to-js: 2.0.0
       unified: 11.0.5
       vfile: 6.0.3
+
+  redent@3.0.0:
+    dependencies:
+      indent-string: 4.0.0
+      strip-indent: 3.0.0
+    optional: true
 
   reflect.getprototypeof@1.0.10:
     dependencies:
@@ -24724,6 +25545,8 @@ snapshots:
   resolve-workspace-root@2.0.0: {}
 
   resolve.exports@1.1.1: {}
+
+  resolve.exports@2.0.3: {}
 
   resolve@1.22.10:
     dependencies:
@@ -25284,6 +26107,11 @@ snapshots:
 
   strip-final-newline@2.0.0: {}
 
+  strip-indent@3.0.0:
+    dependencies:
+      min-indent: 1.0.1
+    optional: true
+
   strip-json-comments@3.1.1: {}
 
   strip-json-comments@5.0.3: {}
@@ -25466,6 +26294,27 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
+  ts-node@10.9.2(@swc/core@1.13.5(@swc/helpers@0.5.18))(@types/node@24.10.1)(typescript@6.0.2):
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.11
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.4
+      '@types/node': 24.10.1
+      acorn: 8.15.0
+      acorn-walk: 8.3.4
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.2
+      make-error: 1.3.6
+      typescript: 6.0.2
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
+    optionalDependencies:
+      '@swc/core': 1.13.5(@swc/helpers@0.5.18)
+    optional: true
+
   ts-node@10.9.2(@swc/core@1.13.5(@swc/helpers@0.5.18))(@types/node@24.5.2)(typescript@6.0.2):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
@@ -25485,6 +26334,27 @@ snapshots:
       yn: 3.1.1
     optionalDependencies:
       '@swc/core': 1.13.5(@swc/helpers@0.5.18)
+
+  ts-node@10.9.2(@swc/core@1.13.5(@swc/helpers@0.5.18))(@types/node@25.3.1)(typescript@6.0.2):
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.11
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.4
+      '@types/node': 25.3.1
+      acorn: 8.15.0
+      acorn-walk: 8.3.4
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.2
+      make-error: 1.3.6
+      typescript: 6.0.2
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
+    optionalDependencies:
+      '@swc/core': 1.13.5(@swc/helpers@0.5.18)
+    optional: true
 
   tsconfck@3.1.6(typescript@6.0.2):
     optionalDependencies:


### PR DESCRIPTION
Add example-local Jest harnesses for expo-kit and expo-web3js with mocked mobile transport and RPC seams.

Update root and pull request validation to run the new example test and lint commands, and surface sign-message success and failure state in expo-web3js so the integration flow is observable.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wallet-ui/wallet-ui/pull/478" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * UI now shows signing status ("Message Signed!" / "Sign Message Failed").

* **Tests**
  * Added end-to-end integration tests for both example apps covering connect, sign, send, cache rehydration, and error flows.

* **Chores**
  * Added Jest test infrastructure, setup helpers, and mocks for the examples.
  * CI updated to run example tests and linting as part of the build-and-test pipeline.
  * Root test script updated to include example test runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->