### PR TITLE
test(examples): add Expo native-entry smoke checks

### DIFF
--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -55,6 +55,9 @@ jobs:
           pnpm --dir examples/expo-kit test
           pnpm --dir examples/expo-web3js test
 
+      - name: Smoke Test Expo Native Entries
+        run: pnpm test:examples:native-entry
+
       - name: Lint Expo Examples
         run: |
           pnpm --dir examples/expo-kit lint

--- a/examples/README.md
+++ b/examples/README.md
@@ -21,3 +21,19 @@ In the directory of a given example, run its start script.
 ```shell
 pnpm start
 ```
+
+## Expo native-entry smoke tests
+
+The Expo smoke coverage bundles the Expo examples through Expo's native iOS path and asserts that the workspace packages resolve `dist/index.native.mjs`, not `dist/index.node.cjs`.
+
+These smoke checks require prebuilt workspace `dist/` artifacts. If the workspace packages have not been built yet, run the following command from the repository root first. A missing `dist/` file is a build prerequisite failure, not a native-entry regression.
+
+```shell
+pnpm build
+```
+
+Run the Expo native-entry smoke checks from the repository root with the following command.
+
+```shell
+pnpm test:examples:native-entry
+```

--- a/examples/expo-kit/package.json
+++ b/examples/expo-kit/package.json
@@ -11,6 +11,7 @@
         "lint": "expo lint",
         "start": "expo start",
         "test": "jest -c ./jest.config.js --runInBand",
+        "test:native-entry": "node ../../scripts/test-expo-native-entry-smoke.mjs @wallet-ui/react-native-kit",
         "web": "expo start --web"
     },
     "dependencies": {

--- a/examples/expo-web3js/package.json
+++ b/examples/expo-web3js/package.json
@@ -11,6 +11,7 @@
     "lint": "expo lint",
     "start": "expo start",
     "test": "jest -c ./jest.config.js --runInBand",
+    "test:native-entry": "node ../../scripts/test-expo-native-entry-smoke.mjs @wallet-ui/react-native-web3js",
     "web": "expo start --web"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
         "style:fix": "turbo  run --concurrency=${TURBO_CONCURRENCY:-95.84%} style:fix && pnpm prettier --log-level warn --ignore-unknown --write '{.,!packages}/*'",
         "test": "turbo run --concurrency=${TURBO_CONCURRENCY:-95.84%} test:unit:browser test:unit:node && pnpm test:examples",
         "test:examples": "pnpm --dir examples/expo-kit test && pnpm --dir examples/expo-web3js test",
+        "test:examples:native-entry": "pnpm --dir examples/expo-kit test:native-entry && pnpm --dir examples/expo-web3js test:native-entry",
         "test:live-with-test-validator": "turbo run --concurrency=${TURBO_CONCURRENCY:-95.84%} test:live-with-test-validator",
         "test:live-with-test-validator:setup": "./scripts/setup-test-validator.sh"
     },

--- a/scripts/test-expo-native-entry-smoke.mjs
+++ b/scripts/test-expo-native-entry-smoke.mjs
@@ -1,0 +1,83 @@
+#!/usr/bin/env node
+
+import { spawnSync } from 'node:child_process';
+import { existsSync, mkdtempSync, readFileSync, readdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+
+const [packageName] = process.argv.slice(2);
+
+if (!packageName) {
+    throw new Error('Usage: node ../../scripts/test-expo-native-entry-smoke.mjs <workspace-package>');
+}
+
+const exampleDir = process.cwd();
+const exampleName = path.basename(exampleDir);
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const workspaceName = packageName.replace('@wallet-ui/', '');
+
+const nativeEntryPath = path.join(repoRoot, 'packages', workspaceName, 'dist', 'index.native.mjs');
+const nodeEntryPath = path.join(repoRoot, 'packages', workspaceName, 'dist', 'index.node.cjs');
+
+if (!existsSync(nativeEntryPath) || !existsSync(nodeEntryPath)) {
+    throw new Error(
+        [
+            `Missing prebuilt workspace artifacts for ${packageName}.`,
+            `Expected ${nativeEntryPath} and ${nodeEntryPath}.`,
+            'Run `pnpm build` from the repository root first.',
+            'This is a workspace build prerequisite failure, not a native-entry regression.',
+        ].join('\n')
+    );
+}
+
+const outputDir = mkdtempSync(path.join(tmpdir(), `${exampleName}-native-entry-`));
+const exportResult = spawnSync(
+    'pnpm',
+    ['exec', 'expo', 'export', '--output-dir', outputDir, '--platform', 'ios', '--source-maps', 'external'],
+    {
+        cwd: exampleDir,
+        stdio: 'inherit',
+    }
+);
+
+if (exportResult.status !== 0) {
+    process.exit(exportResult.status ?? 1);
+}
+
+const bundleDir = path.join(outputDir, '_expo', 'static', 'js', 'ios');
+const sourceMapName = readdirSync(bundleDir)
+    .filter(fileName => fileName.endsWith('.map'))
+    .sort()[0];
+
+if (!sourceMapName) {
+    throw new Error(`No iOS source map was generated in ${bundleDir}.`);
+}
+
+const sourceMap = JSON.parse(readFileSync(path.join(bundleDir, sourceMapName), 'utf8'));
+const sources = Array.isArray(sourceMap.sources) ? sourceMap.sources : [];
+const distSources = sources.filter(sourcePath => sourcePath.includes(`/packages/${workspaceName}/dist/index.`));
+const nativeEntrySuffix = `/packages/${workspaceName}/dist/index.native.mjs`;
+const nodeEntrySuffix = `/packages/${workspaceName}/dist/index.node.cjs`;
+
+if (distSources.some(sourcePath => sourcePath.includes(nodeEntrySuffix))) {
+    throw new Error(
+        [
+            `Expected ${packageName} to resolve its native entrypoint while bundling ${exampleName}.`,
+            `Found the Node bundle in the Expo iOS source map: ${nodeEntrySuffix}`,
+        ].join('\n')
+    );
+}
+
+if (!distSources.some(sourcePath => sourcePath.includes(nativeEntrySuffix))) {
+    throw new Error(
+        [
+            `Expected ${packageName} to resolve ${nativeEntrySuffix} while bundling ${exampleName}.`,
+            'Resolved dist sources:',
+            distSources.length > 0 ? distSources.join('\n') : '(none)',
+        ].join('\n')
+    );
+}
+
+console.log(`Verified ${packageName} resolved ${nativeEntrySuffix} while bundling ${exampleName}.`);


### PR DESCRIPTION
Add Expo native-entry smoke commands for the Expo examples and verify their bundles resolve the native workspace entrypoints instead of the Node bundle.

Run the new smoke check in PR CI and document the required prebuilt dist artifact prerequisite.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wallet-ui/wallet-ui/pull/479" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added native-entry smoke tests for Expo examples to validate correct entry point resolution during bundling.

* **Documentation**
  * Added documentation describing the new native-entry smoke tests, prerequisites, and how to execute them.

* **Chores**
  * Integrated native-entry tests into the CI pipeline to run automatically alongside existing example tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->