### PR TITLE
chore: fix changeset frontmatter

### DIFF
--- a/.changeset/tame-planes-attend.md
+++ b/.changeset/tame-planes-attend.md
@@ -1,3 +1,4 @@
+---
 '@wallet-ui/react-native-kit': patch
 '@wallet-ui/react-native-web3js': patch
 ---


### PR DESCRIPTION
Restore the missing opening frontmatter delimiter in the changeset for the React Native package version bump.

This lets Changesets parse the file again so the canary publish step can run without failing on invalid frontmatter.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wallet-ui/wallet-ui/pull/481" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package versioning configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->