### PR TITLE
ci: add Codecov coverage upload workflow

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -1,0 +1,39 @@
+name: Codecov
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  published-package-coverage:
+    name: Published Package Coverage
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Dependencies
+        uses: ./.github/workflows/actions/install-dependencies
+
+      - name: Compile Published Packages
+        run: pnpm turbo compile:js --filter=@wallet-ui/core --filter=@wallet-ui/react --filter=@wallet-ui/react-native-kit --filter=@wallet-ui/react-native-web3js
+
+      - name: Generate Coverage
+        run: pnpm run test:coverage:packages
+
+      - name: Upload Coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          disable_search: true
+          fail_ci_if_error: true
+          files: ./tmp/coverage/published-packages/lcov.info
+          flags: published-packages
+          name: published-packages
+          use_oidc: true
+          verbose: true

--- a/scripts/test-coverage-published-packages.mjs
+++ b/scripts/test-coverage-published-packages.mjs
@@ -26,6 +26,7 @@ const coveragePatterns = [
     '!src/**/test-utils/**',
 ];
 const publishedPackages = getPublishedPackages();
+const repositoryCoverageMap = createCoverageMap({});
 
 if (publishedPackages.length === 0) {
     throw new Error(`No published packages were found in ${packagesRoot}.`);
@@ -48,6 +49,8 @@ for (const pkg of publishedPackages) {
         continue;
     }
 
+    repositoryCoverageMap.merge(result.coverageMap);
+
     console.log(
         [
             `Completed ${pkg.name}.`,
@@ -56,6 +59,15 @@ for (const pkg of publishedPackages) {
             `Functions ${formatMetric(result.summary.functions)}.`,
             `Lines ${formatMetric(result.summary.lines)}.`,
         ].join(' '),
+    );
+}
+
+if (repositoryCoverageMap.files().length > 0) {
+    reports.create('lcovonly').execute(
+        libReport.createContext({
+            coverageMap: repositoryCoverageMap,
+            dir: outputRoot,
+        }),
     );
 }
 
@@ -286,6 +298,7 @@ function runCoverageForPackage(pkg) {
         reports.create('html').execute(reportContext);
 
         return {
+            coverageMap,
             directoryName: pkg.directoryName,
             name: pkg.name,
             status: 'ok',


### PR DESCRIPTION
Generate a merged LCOV report from the published package coverage run and upload it to Codecov from GitHub Actions using OIDC.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wallet-ui/wallet-ui/pull/485" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated coverage reporting to the CI pipeline, including upload of package coverage to Codecov.

* **Tests**
  * Enhanced coverage tooling to aggregate results across packages and emit a consolidated root-level coverage report.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->