### PR TITLE
test(react): add provider coverage

### DIFF
--- a/packages/react/src/__tests__/dummy-test.ts
+++ b/packages/react/src/__tests__/dummy-test.ts
@@ -1,5 +1,0 @@
-describe('dummy', () => {
-    it('should return something', () => {
-        expect(true).toBe(true);
-    });
-});

--- a/packages/react/src/__tests__/wallet-ui-account-context-provider-actions-test.tsx
+++ b/packages/react/src/__tests__/wallet-ui-account-context-provider-actions-test.tsx
@@ -1,0 +1,210 @@
+import type { SolanaCluster } from '@wallet-ui/core';
+
+import {
+    createAccount,
+    createWallet,
+    type TestAccount,
+    type TestWallet,
+} from '../test-utils/wallet-ui-test-utils';
+
+const CLUSTER: SolanaCluster = {
+    id: 'solana:testnet',
+    label: 'Testnet',
+    url: 'https://api.testnet.solana.com',
+};
+
+const mockUseWallets = jest.fn();
+let mockWallets: TestWallet[] = [];
+
+jest.mock('@wallet-standard/react', () => {
+    const { mockWalletStandardReact } = jest.requireActual<typeof import('../test-utils/wallet-ui-test-utils')>(
+        '../test-utils/wallet-ui-test-utils',
+    );
+    return mockWalletStandardReact(() => mockUseWallets());
+});
+
+describe('WalletUiAccountContextProvider actions', () => {
+    const cleanups: Array<() => void> = [];
+
+    beforeEach(() => {
+        jest.useFakeTimers();
+        mockUseWallets.mockReset();
+        mockUseWallets.mockImplementation(() => mockWallets);
+        mockWallets = [];
+    });
+
+    afterEach(() => {
+        for (const cleanup of cleanups.splice(0).reverse()) {
+            cleanup();
+        }
+        jest.runOnlyPendingTimers();
+        jest.useRealTimers();
+    });
+
+    it('stores the selected account and exposes it through context', () => {
+        expect.assertions(4);
+
+        const account = createAccount({ address: 'phantom-1', walletName: 'Phantom' });
+        const wallet = createWallet({ accounts: [account], name: 'Phantom' });
+        const view = renderProvider(cleanups, [wallet]);
+
+        view.act(() => {
+            view.getContext().setAccount(account);
+        });
+
+        expect(view.storage.get()).toBe('Phantom:phantom-1');
+        expect(view.getContext().account).toEqual(account);
+        expect(view.getContext().accountKeys).toEqual(['solana:testnet', 'Phantom:phantom-1']);
+        expect(view.getContext().wallet?.name).toBe('Phantom');
+    });
+
+    it('clears the selected account and storage when set to undefined', () => {
+        expect.assertions(4);
+
+        const account = createAccount({ address: 'phantom-1', walletName: 'Phantom' });
+        const wallet = createWallet({ accounts: [account], name: 'Phantom' });
+        const view = renderProvider(cleanups, [wallet]);
+
+        view.act(() => {
+            view.getContext().setAccount(account);
+        });
+        view.act(() => {
+            view.getContext().setAccount(undefined);
+        });
+
+        expect(view.storage.get()).toBeUndefined();
+        expect(view.getContext().account).toBeUndefined();
+        expect(view.getContext().accountKeys).toEqual([]);
+        expect(view.getContext().wallet).toBeUndefined();
+    });
+
+    it('does not auto-reselect a saved account after an explicit selection has occurred', () => {
+        expect.assertions(5);
+
+        const account = createAccount({ address: 'phantom-1', walletName: 'Phantom' });
+        const wallet = createWallet({ accounts: [account], name: 'Phantom' });
+        const view = renderProvider(cleanups, [wallet]);
+
+        view.act(() => {
+            view.getContext().setAccount(account);
+        });
+        view.rerender([]);
+
+        expect(view.getContext().account).toBeUndefined();
+        expect(view.storage.get()).toBe('Phantom:phantom-1');
+
+        view.rerender([wallet]);
+
+        expect(view.getContext().account).toBeUndefined();
+        expect(view.getContext().accountKeys).toEqual([]);
+        expect(view.getContext().wallet).toBeUndefined();
+    });
+});
+
+function renderProvider(cleanups: Array<() => void>, initialWallets: TestWallet[]) {
+    mockWallets = initialWallets;
+
+    let harness:
+        | {
+              act: typeof import('react-test-renderer').act;
+              getContext(): {
+                  account?: TestAccount;
+                  accountKeys: string[];
+                  setAccount(value: TestAccount | undefined): void;
+                  wallet?: TestWallet;
+              };
+              rerender(nextWallets: TestWallet[]): void;
+              storage: { get(): string | undefined };
+              unmount(): void;
+          }
+        | undefined;
+
+    jest.isolateModules(() => {
+        const React = jest.requireActual<typeof import('react')>('react');
+        const persistent: {
+            getTestStorage(): Record<string, string | undefined>;
+            useTestStorageEngine(): void;
+        } = jest.requireActual('@nanostores/persistent');
+        const { getTestStorage, useTestStorageEngine } = persistent;
+        const { createStorageAccount } = jest.requireActual<typeof import('@wallet-ui/core')>('@wallet-ui/core');
+        const { act, create } =
+            jest.requireActual<typeof import('react-test-renderer')>('react-test-renderer');
+        const { WalletUiAccountContext } =
+            jest.requireActual<typeof import('../wallet-ui-account-context')>('../wallet-ui-account-context');
+        const { WalletUiAccountContextProvider } =
+            jest.requireActual<typeof import('../wallet-ui-account-context-provider')>(
+                '../wallet-ui-account-context-provider',
+            );
+
+        let contextValue:
+            | {
+                  account?: TestAccount;
+                  accountKeys: string[];
+                  setAccount(value: TestAccount | undefined): void;
+                  wallet?: TestWallet;
+              }
+            | undefined;
+
+        useTestStorageEngine();
+        resetTestStorage(getTestStorage());
+        const storage = createStorageAccount();
+
+        function Probe() {
+            contextValue = React.useContext(WalletUiAccountContext) as typeof contextValue;
+            return null;
+        }
+
+        const renderNode = () =>
+            React.createElement(WalletUiAccountContextProvider, {
+                children: React.createElement(Probe),
+                cluster: CLUSTER,
+                storage,
+            });
+
+        let renderer!: ReturnType<typeof create>;
+
+        act(() => {
+            renderer = create(renderNode());
+        });
+
+        harness = {
+            act,
+            getContext() {
+                if (!contextValue) {
+                    throw new Error('Missing account context value');
+                }
+                return contextValue;
+            },
+            rerender(nextWallets: TestWallet[]) {
+                mockWallets = nextWallets;
+                act(() => {
+                    renderer.update(renderNode());
+                });
+            },
+            storage,
+            unmount() {
+                act(() => {
+                    renderer.unmount();
+                });
+            },
+        };
+    });
+
+    if (!harness) {
+        throw new Error('Failed to create account provider harness');
+    }
+
+    const result = harness;
+
+    cleanups.push(() => {
+        result.unmount();
+    });
+
+    return result;
+}
+
+function resetTestStorage(storage: Record<string, string | undefined>) {
+    for (const key of Object.keys(storage)) {
+        delete storage[key];
+    }
+}

--- a/packages/react/src/__tests__/wallet-ui-account-context-provider-test.tsx
+++ b/packages/react/src/__tests__/wallet-ui-account-context-provider-test.tsx
@@ -1,0 +1,179 @@
+import { createStorageAccount, type SolanaCluster } from '@wallet-ui/core';
+import React, { useContext } from 'react';
+import { act, create } from 'react-test-renderer';
+
+import {
+    createAccount,
+    createWallet,
+    type TestAccount,
+    type TestWallet,
+} from '../test-utils/wallet-ui-test-utils';
+import { WalletUiAccountContext } from '../wallet-ui-account-context';
+import { WalletUiAccountContextProvider } from '../wallet-ui-account-context-provider';
+
+const CLUSTER: SolanaCluster = {
+    id: 'solana:testnet',
+    label: 'Testnet',
+    url: 'https://api.testnet.solana.com',
+};
+
+const mockUseWallets = jest.fn();
+let mockWallets: TestWallet[] = [];
+
+jest.mock('@wallet-standard/react', () => {
+    const { mockWalletStandardReact } = jest.requireActual<typeof import('../test-utils/wallet-ui-test-utils')>(
+        '../test-utils/wallet-ui-test-utils',
+    );
+    return mockWalletStandardReact(() => mockUseWallets());
+});
+
+describe('WalletUiAccountContextProvider', () => {
+    const cleanups: Array<() => void> = [];
+
+    beforeEach(() => {
+        jest.useFakeTimers();
+        resetPersistentTestStorage();
+        mockUseWallets.mockReset();
+        mockUseWallets.mockImplementation(() => mockWallets);
+        mockWallets = [];
+    });
+
+    afterEach(() => {
+        for (const cleanup of cleanups.splice(0).reverse()) {
+            cleanup();
+        }
+        jest.runOnlyPendingTimers();
+        jest.useRealTimers();
+    });
+
+    it('restores the saved account and exposes the resolved wallet metadata', () => {
+        expect.assertions(3);
+
+        const phantomAccount = createAccount({ address: 'phantom-1', walletName: 'Phantom' });
+        const phantomWallet = createWallet({ accounts: [phantomAccount], name: 'Phantom' });
+        const storage = createStorageAccount();
+
+        storage.set('Phantom:phantom-1');
+
+        const view = renderProvider({ cleanups, storage, wallets: [phantomWallet] });
+
+        expect(view.getContext().account).toBe(phantomAccount);
+        expect(view.getContext().accountKeys).toEqual(['solana:testnet', 'Phantom:phantom-1']);
+        expect(view.getContext().wallet).toBe(phantomWallet);
+    });
+
+    it('falls back to another account from the same wallet when the selected account disappears', () => {
+        expect.assertions(3);
+
+        const phantomAccount = createAccount({ address: 'phantom-1', walletName: 'Phantom' });
+        const replacementAccount = createAccount({ address: 'phantom-2', walletName: 'Phantom' });
+        const storage = createStorageAccount();
+
+        storage.set('Phantom:phantom-1');
+
+        const view = renderProvider({
+            cleanups,
+            storage,
+            wallets: [createWallet({ accounts: [phantomAccount], name: 'Phantom' })],
+        });
+
+        view.rerender([createWallet({ accounts: [replacementAccount], name: 'Phantom' })]);
+
+        expect(view.getContext().account).toBe(replacementAccount);
+        expect(view.getContext().accountKeys).toEqual(['solana:testnet', 'Phantom:phantom-2']);
+        expect(view.getContext().wallet?.name).toBe('Phantom');
+    });
+
+    it('clears the selected account when its wallet disappears from the registry', () => {
+        expect.assertions(3);
+
+        const phantomAccount = createAccount({ address: 'phantom-1', walletName: 'Phantom' });
+        const storage = createStorageAccount();
+
+        storage.set('Phantom:phantom-1');
+
+        const view = renderProvider({
+            cleanups,
+            storage,
+            wallets: [createWallet({ accounts: [phantomAccount], name: 'Phantom' })],
+        });
+
+        view.rerender([createWallet({ accounts: [], name: 'Solflare' })]);
+
+        expect(view.getContext().account).toBeUndefined();
+        expect(view.getContext().accountKeys).toEqual([]);
+        expect(view.getContext().wallet).toBeUndefined();
+    });
+});
+
+function renderProvider({
+    cleanups,
+    storage,
+    wallets,
+}: {
+    cleanups: Array<() => void>;
+    storage: ReturnType<typeof createStorageAccount>;
+    wallets: TestWallet[];
+}) {
+    mockWallets = wallets;
+
+    let contextValue:
+        | {
+              account?: TestAccount;
+              accountKeys: string[];
+              wallet?: TestWallet;
+          }
+        | undefined;
+
+    function Probe() {
+        contextValue = useContext(WalletUiAccountContext) as typeof contextValue;
+        return null;
+    }
+
+    const renderNode = () => (
+        <WalletUiAccountContextProvider cluster={CLUSTER} storage={storage}>
+            <Probe />
+        </WalletUiAccountContextProvider>
+    );
+
+    let renderer!: ReturnType<typeof create>;
+
+    act(() => {
+        renderer = create(renderNode());
+    });
+
+    cleanups.push(() => {
+        act(() => {
+            renderer.unmount();
+        });
+    });
+
+    return {
+        getContext() {
+            if (!contextValue) {
+                throw new Error('Missing account context value');
+            }
+            return contextValue;
+        },
+        rerender(nextWallets: TestWallet[]) {
+            mockWallets = nextWallets;
+            act(() => {
+                renderer.update(renderNode());
+            });
+        },
+    };
+}
+
+function resetPersistentTestStorage() {
+    const persistent: {
+        getTestStorage(): Record<string, string | undefined>;
+        useTestStorageEngine(): void;
+    } = jest.requireActual('@nanostores/persistent');
+    const installTestStorageEngine = persistent.useTestStorageEngine;
+
+    installTestStorageEngine();
+    const storage = persistent.getTestStorage();
+    for (const key of Object.keys(storage)) {
+        delete storage[key];
+    }
+}

--- a/packages/react/src/__tests__/wallet-ui-cluster-context-provider-test.tsx
+++ b/packages/react/src/__tests__/wallet-ui-cluster-context-provider-test.tsx
@@ -1,0 +1,186 @@
+import { createStorageCluster, type SolanaCluster } from '@wallet-ui/core';
+import React, { useContext } from 'react';
+import { act, create } from 'react-test-renderer';
+
+import { WalletUiClusterContext } from '../wallet-ui-cluster-context';
+import { WalletUiClusterContextProvider } from '../wallet-ui-cluster-context-provider';
+
+const CLUSTERS: SolanaCluster[] = [
+    {
+        id: 'solana:devnet',
+        label: 'Devnet',
+        url: 'https://api.devnet.solana.com',
+    },
+    {
+        id: 'solana:mainnet',
+        label: 'Mainnet',
+        url: 'https://api.mainnet-beta.solana.com',
+    },
+    {
+        id: 'solana:testnet',
+        label: 'Testnet',
+        url: 'https://api.testnet.solana.com',
+    },
+];
+
+describe('WalletUiClusterContextProvider', () => {
+    const cleanups: Array<() => void> = [];
+
+    beforeEach(() => {
+        jest.useFakeTimers();
+        resetPersistentTestStorage();
+    });
+
+    afterEach(() => {
+        for (const cleanup of cleanups.splice(0).reverse()) {
+            cleanup();
+        }
+        jest.runOnlyPendingTimers();
+        jest.useRealTimers();
+    });
+
+    it('throws when no clusters are provided', () => {
+        expect.assertions(1);
+
+        const storage = createStorageCluster();
+
+        expect(() =>
+            act(() => {
+                create(
+                    <WalletUiClusterContextProvider clusters={[]} render={() => null} storage={storage} />,
+                );
+            }),
+        ).toThrow('No clusters provided');
+    });
+
+    it('restores the stored cluster when the stored id exists', () => {
+        expect.assertions(2);
+
+        const storage = createStorageCluster();
+
+        storage.set('solana:testnet');
+
+        const view = renderProvider({ cleanups, clusters: CLUSTERS, storage });
+
+        expect(view.getContext().cluster).toBe(CLUSTERS[2]);
+        expect(view.getRenderValue().cluster).toBe(CLUSTERS[2]);
+    });
+
+    it('falls back to the first cluster when the stored id is missing', () => {
+        expect.assertions(2);
+
+        const storage = createStorageCluster();
+
+        storage.set('solana:devnet');
+
+        const view = renderProvider({
+            cleanups,
+            clusters: [CLUSTERS[1], CLUSTERS[2]],
+            storage,
+        });
+
+        expect(view.getContext().cluster).toBe(CLUSTERS[1]);
+        expect(view.getRenderValue().cluster).toBe(CLUSTERS[1]);
+    });
+
+    it('persists a valid cluster selection and updates the exposed cluster', () => {
+        expect.assertions(3);
+
+        const storage = createStorageCluster();
+        const view = renderProvider({ cleanups, clusters: CLUSTERS, storage });
+
+        act(() => {
+            view.getContext().setCluster('solana:testnet');
+        });
+
+        expect(storage.get()).toBe('solana:testnet');
+        expect(view.getContext().cluster).toBe(CLUSTERS[2]);
+        expect(view.getRenderValue().cluster).toBe(CLUSTERS[2]);
+    });
+
+    it('throws when selecting a cluster that is not in the provided list', () => {
+        expect.assertions(2);
+
+        const storage = createStorageCluster();
+        const view = renderProvider({ cleanups, clusters: CLUSTERS, storage });
+
+        expect(() => {
+            view.getContext().setCluster('solana:localnet');
+        }).toThrow('Cluster solana:localnet not found');
+        expect(storage.get()).toBe('solana:devnet');
+    });
+});
+
+function renderProvider({
+    cleanups,
+    clusters,
+    storage,
+}: {
+    cleanups: Array<() => void>;
+    clusters: SolanaCluster[];
+    storage: ReturnType<typeof createStorageCluster>;
+}) {
+    let contextValue:
+        | {
+              cluster: SolanaCluster;
+              clusters: SolanaCluster[];
+              setCluster(clusterId: `solana:${string}`): void;
+          }
+        | undefined;
+    let renderValue: typeof contextValue;
+
+    function Probe() {
+        contextValue = useContext(WalletUiClusterContext) as typeof contextValue;
+        return null;
+    }
+
+    let renderer!: ReturnType<typeof create>;
+
+    act(() => {
+        renderer = create(
+            <WalletUiClusterContextProvider
+                clusters={clusters}
+                render={value => {
+                    renderValue = value as typeof renderValue;
+                    return <Probe />;
+                }}
+                storage={storage}
+            />,
+        );
+    });
+
+    cleanups.push(() => {
+        act(() => {
+            renderer.unmount();
+        });
+    });
+
+    return {
+        getContext() {
+            if (!contextValue) {
+                throw new Error('Missing cluster context value');
+            }
+            return contextValue;
+        },
+        getRenderValue() {
+            if (!renderValue) {
+                throw new Error('Missing render prop value');
+            }
+            return renderValue;
+        },
+    };
+}
+
+function resetPersistentTestStorage() {
+    const persistent: {
+        getTestStorage(): Record<string, string | undefined>;
+        useTestStorageEngine(): void;
+    } = jest.requireActual('@nanostores/persistent');
+    const installTestStorageEngine = persistent.useTestStorageEngine;
+
+    installTestStorageEngine();
+    const storage = persistent.getTestStorage();
+    for (const key of Object.keys(storage)) {
+        delete storage[key];
+    }
+}

--- a/packages/react/src/__tests__/wallet-ui-context-provider-test.tsx
+++ b/packages/react/src/__tests__/wallet-ui-context-provider-test.tsx
@@ -1,0 +1,163 @@
+import type { SolanaCluster } from '@wallet-ui/core';
+import React, { useContext } from 'react';
+import { act, create } from 'react-test-renderer';
+
+import {
+    createAccount,
+    createWallet,
+    type TestAccount,
+    type TestWallet,
+} from '../test-utils/wallet-ui-test-utils';
+import { WalletUiAccountContext } from '../wallet-ui-account-context';
+import { WalletUiContext } from '../wallet-ui-context';
+import { WalletUiContextProvider } from '../wallet-ui-context-provider';
+
+const CLUSTER: SolanaCluster = {
+    id: 'solana:testnet',
+    label: 'Testnet',
+    url: 'https://api.testnet.solana.com',
+};
+
+const mockHandleCopyText = jest.fn();
+const mockUseWallets = jest.fn();
+let mockWallets: TestWallet[] = [];
+const cleanups: Array<() => void> = [];
+
+jest.mock('@wallet-standard/react', () => {
+    const { mockWalletStandardReact } = jest.requireActual<typeof import('../test-utils/wallet-ui-test-utils')>(
+        '../test-utils/wallet-ui-test-utils',
+    );
+    return mockWalletStandardReact(() => mockUseWallets());
+});
+
+jest.mock('@wallet-ui/core', () => ({
+    handleCopyText: (...args: unknown[]) => mockHandleCopyText(...args),
+}));
+
+describe('WalletUiContextProvider', () => {
+    beforeEach(() => {
+        mockHandleCopyText.mockReset();
+        mockUseWallets.mockReset();
+        mockUseWallets.mockImplementation(() => mockWallets);
+        mockWallets = [];
+    });
+
+    afterEach(() => {
+        for (const cleanup of cleanups.splice(0).reverse()) {
+            cleanup();
+        }
+    });
+
+    it('filters to Solana wallets, sorts them alphabetically, and reports disconnected state when no account is selected', () => {
+        expect.assertions(3);
+
+        const setAccount = jest.fn();
+        const backpackWallet = createWallet({ accounts: [], name: 'Backpack' });
+        const ethereumWallet = createWallet({ chains: ['eip155:1'], name: 'Ethereum Wallet' });
+        const solflareWallet = createWallet({ accounts: [], name: 'Solflare' });
+        const view = renderProvider({
+            account: undefined,
+            setAccount,
+            wallet: undefined,
+            wallets: [solflareWallet, ethereumWallet, backpackWallet],
+        });
+
+        expect(view.getContext().connected).toBe(false);
+        expect(view.getContext().wallets.map(wallet => wallet.name)).toEqual(['Backpack', 'Solflare']);
+
+        view.getContext().copy();
+
+        expect(mockHandleCopyText).not.toHaveBeenCalled();
+    });
+
+    it('delegates connect, disconnect, and copy through the account context state', () => {
+        expect.assertions(4);
+
+        const account = createAccount({ address: 'phantom-1', walletName: 'Phantom' });
+        const setAccount = jest.fn();
+        const wallet = createWallet({ accounts: [account], name: 'Phantom' });
+        const view = renderProvider({
+            account,
+            setAccount,
+            wallet,
+            wallets: [wallet],
+        });
+
+        expect(view.getContext().connected).toBe(true);
+
+        view.getContext().connect(account);
+        view.getContext().disconnect();
+        view.getContext().copy();
+
+        expect(setAccount).toHaveBeenNthCalledWith(1, account);
+        expect(setAccount).toHaveBeenNthCalledWith(2, undefined);
+        expect(mockHandleCopyText).toHaveBeenCalledWith('phantom-1');
+    });
+});
+
+function renderProvider({
+    account,
+    setAccount,
+    wallet,
+    wallets,
+}: {
+    account: TestAccount | undefined;
+    setAccount: jest.Mock;
+    wallet: TestWallet | undefined;
+    wallets: TestWallet[];
+}) {
+    mockWallets = wallets;
+
+    let contextValue:
+        | {
+              account?: TestAccount;
+              accountKeys: string[];
+              connect(account: TestAccount): void;
+              connected: boolean;
+              copy(): void;
+              disconnect(): void;
+              wallet?: TestWallet;
+              wallets: TestWallet[];
+          }
+        | undefined;
+
+    function Probe() {
+        contextValue = useContext(WalletUiContext) as unknown as typeof contextValue;
+        return null;
+    }
+
+    const accountContextValue = {
+        account,
+        accountKeys: account ? [CLUSTER.id, `${account.walletName}:${account.address}`] : [],
+        cluster: CLUSTER,
+        setAccount,
+        wallet,
+    } as unknown as React.ContextType<typeof WalletUiAccountContext>;
+
+    let renderer!: ReturnType<typeof create>;
+
+    act(() => {
+        renderer = create(
+            <WalletUiAccountContext.Provider value={accountContextValue}>
+                <WalletUiContextProvider>
+                    <Probe />
+                </WalletUiContextProvider>
+            </WalletUiAccountContext.Provider>,
+        );
+    });
+
+    cleanups.push(() => {
+        act(() => {
+            renderer.unmount();
+        });
+    });
+
+    return {
+        getContext() {
+            if (!contextValue) {
+                throw new Error('Missing wallet UI context value');
+            }
+            return contextValue;
+        },
+    };
+}

--- a/packages/react/src/__tests__/wallet-ui-test.tsx
+++ b/packages/react/src/__tests__/wallet-ui-test.tsx
@@ -1,0 +1,164 @@
+import { createStorageAccount, createStorageCluster, type SolanaCluster } from '@wallet-ui/core';
+import React from 'react';
+import { act, create } from 'react-test-renderer';
+
+import {
+    createAccount,
+    createWallet,
+    type TestAccount,
+    type TestWallet,
+} from '../test-utils/wallet-ui-test-utils';
+import { useWalletUi } from '../use-wallet-ui';
+import { WalletUi } from '../wallet-ui';
+
+const CLUSTERS: SolanaCluster[] = [
+    {
+        id: 'solana:devnet',
+        label: 'Devnet',
+        url: 'https://api.devnet.solana.com',
+    },
+    {
+        id: 'solana:testnet',
+        label: 'Testnet',
+        url: 'https://api.testnet.solana.com',
+    },
+];
+
+const mockUseWallets = jest.fn();
+let mockWallets: TestWallet[] = [];
+
+jest.mock('@wallet-standard/react', () => {
+    const { mockWalletStandardReact } = jest.requireActual<typeof import('../test-utils/wallet-ui-test-utils')>(
+        '../test-utils/wallet-ui-test-utils',
+    );
+    return mockWalletStandardReact(() => mockUseWallets());
+});
+
+describe('WalletUi', () => {
+    const cleanups: Array<() => void> = [];
+
+    beforeEach(() => {
+        jest.useFakeTimers();
+        resetPersistentTestStorage();
+        mockUseWallets.mockReset();
+        mockUseWallets.mockImplementation(() => mockWallets);
+        mockWallets = [];
+    });
+
+    afterEach(() => {
+        for (const cleanup of cleanups.splice(0).reverse()) {
+            cleanup();
+        }
+        jest.runOnlyPendingTimers();
+        jest.useRealTimers();
+    });
+
+    it('restores stored provider state and clears the selected account on disconnect', () => {
+        expect.assertions(9);
+
+        const account = createAccount({ address: 'phantom-1', walletName: 'Phantom' });
+        const accountStorage = createStorageAccount();
+        const clusterStorage = createStorageCluster();
+        const wallet = createWallet({ accounts: [account], name: 'Phantom' });
+
+        accountStorage.set('Phantom:phantom-1');
+        clusterStorage.set('solana:testnet');
+
+        const view = renderWalletUi({
+            accountStorage,
+            cleanups,
+            clusterStorage,
+            wallets: [wallet],
+        });
+
+        expect(view.getContext().account).toBe(account);
+        expect(view.getContext().accountKeys).toEqual(['solana:testnet', 'Phantom:phantom-1']);
+        expect(view.getContext().cluster).toBe(CLUSTERS[1]);
+        expect(view.getContext().connected).toBe(true);
+        expect(view.getContext().wallet).toBe(wallet);
+
+        act(() => {
+            view.getContext().disconnect();
+        });
+
+        expect(accountStorage.get()).toBeUndefined();
+        expect(view.getContext().account).toBeUndefined();
+        expect(view.getContext().connected).toBe(false);
+        expect(view.getContext().wallet).toBeUndefined();
+    });
+});
+
+function renderWalletUi({
+    accountStorage,
+    cleanups,
+    clusterStorage,
+    wallets,
+}: {
+    accountStorage: ReturnType<typeof createStorageAccount>;
+    cleanups: Array<() => void>;
+    clusterStorage: ReturnType<typeof createStorageCluster>;
+    wallets: TestWallet[];
+}) {
+    mockWallets = wallets;
+
+    let contextValue:
+        | {
+              account?: TestAccount;
+              accountKeys: string[];
+              cluster: SolanaCluster;
+              connected: boolean;
+              disconnect(): void;
+              wallet?: TestWallet;
+          }
+        | undefined;
+
+    function Probe() {
+        contextValue = useWalletUi() as typeof contextValue;
+        return null;
+    }
+
+    let renderer!: ReturnType<typeof create>;
+
+    act(() => {
+        renderer = create(
+            <WalletUi
+                config={{
+                    accountStorage,
+                    clusterStorage,
+                    clusters: CLUSTERS,
+                }}
+            >
+                <Probe />
+            </WalletUi>,
+        );
+    });
+
+    cleanups.push(() => {
+        act(() => {
+            renderer.unmount();
+        });
+    });
+
+    return {
+        getContext() {
+            if (!contextValue) {
+                throw new Error('Missing wallet UI value');
+            }
+            return contextValue;
+        },
+    };
+}
+
+function resetPersistentTestStorage() {
+    const persistent: {
+        getTestStorage(): Record<string, string | undefined>;
+        useTestStorageEngine(): void;
+    } = jest.requireActual('@nanostores/persistent');
+    const installTestStorageEngine = persistent.useTestStorageEngine;
+
+    installTestStorageEngine();
+    const storage = persistent.getTestStorage();
+    for (const key of Object.keys(storage)) {
+        delete storage[key];
+    }
+}

--- a/packages/react/src/test-utils/wallet-ui-test-utils.ts
+++ b/packages/react/src/test-utils/wallet-ui-test-utils.ts
@@ -1,0 +1,46 @@
+export type TestAccount = {
+    address: string;
+    label: string;
+    walletName: string;
+};
+
+export type TestWallet = {
+    accounts: TestAccount[];
+    chains: string[];
+    name: string;
+};
+
+export function createAccount({
+    address,
+    label = address,
+    walletName,
+}: {
+    address: string;
+    label?: string;
+    walletName: string;
+}) {
+    return { address, label, walletName };
+}
+
+export function createWallet({
+    accounts = [],
+    chains = ['solana:devnet'],
+    name,
+}: {
+    accounts?: TestAccount[];
+    chains?: string[];
+    name: string;
+}) {
+    return { accounts, chains, name };
+}
+
+export function mockWalletStandardReact(useWallets: () => TestWallet[]) {
+    return {
+        getUiWalletAccountStorageKey: (account: TestAccount) => `${account.walletName}:${account.address}`,
+        uiWalletAccountBelongsToUiWallet: (account: TestAccount, wallet: TestWallet) =>
+            account.walletName === wallet.name,
+        uiWalletAccountsAreSame: (a: TestAccount, b: TestAccount) =>
+            a.address === b.address && a.walletName === b.walletName,
+        useWallets,
+    };
+}


### PR DESCRIPTION
Add focused provider tests for WalletUi account, cluster, context, and composed provider behavior.

Make the new coverage pass in both browser and node unit environments by cleaning up renderer mounts and nanostores timers.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wallet-ui/wallet-ui/pull/486" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive tests for account context provider: selection, persistence, clearing, and behavior when wallets change (including action-focused scenarios).
  * Added tests for cluster context provider: restoration, fallback, persistence, and error handling for invalid selections.
  * Added tests for overall Wallet UI provider and context interactions, including connect/disconnect and copy behavior.
  * Added test utilities to create mock wallets/accounts and mock wallet hooks.
  * Removed a placeholder dummy test.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->