### PR TITLE
test(react): add wallet-ui hook coverage

### DIFF
--- a/packages/react/src/__tests__/wallet-ui-components-test.tsx
+++ b/packages/react/src/__tests__/wallet-ui-components-test.tsx
@@ -1,0 +1,563 @@
+import type { UiWallet, UiWalletAccount } from '@wallet-standard/react';
+import React from 'react';
+import { act, create } from 'react-test-renderer';
+import type { BaseModalProps } from '../base-modal';
+import type { BaseModalControl } from '../use-base-modal';
+
+import { type WalletUiAccountState, WalletUiAccountContext } from '../wallet-ui-account-context';
+import { WalletUiAccountGuard } from '../wallet-ui-account-guard';
+import { type WalletUiClusterContextValue, WalletUiClusterContext } from '../wallet-ui-cluster-context';
+import { WalletUiClusterDropdown } from '../wallet-ui-cluster-dropdown';
+import { WalletUiDropdown } from '../wallet-ui-dropdown';
+import { WalletUiIconClose } from '../wallet-ui-icon-close';
+import { WalletUiIconNoWallet } from '../wallet-ui-icon-no-wallet';
+import { WalletUiIcon } from '../wallet-ui-icon';
+import { WalletUiLabel } from '../wallet-ui-label';
+import { WalletUiListButton } from '../wallet-ui-list-button';
+import { WalletUiList } from '../wallet-ui-list';
+import { WalletUiModalTrigger } from '../wallet-ui-modal-trigger';
+import { WalletUiModal } from '../wallet-ui-modal';
+import { createAccount, createWallet } from '../test-utils/wallet-ui-test-utils';
+
+const mockBaseModal = jest.fn();
+const mockUseBaseDropdown = jest.fn();
+const mockUseWalletUiDropdown = jest.fn();
+const TEST_ICON = 'data:image/png;base64,ZmFrZQ==';
+
+afterEach(() => {
+    mockBaseModal.mockReset();
+    mockUseBaseDropdown.mockReset();
+    mockUseWalletUiDropdown.mockReset();
+});
+
+jest.mock('../base-modal', () => {
+    const React = jest.requireActual<typeof import('react')>('react');
+
+    return {
+        BaseModal: (props: BaseModalProps) => {
+            mockBaseModal(props);
+            return React.createElement(React.Fragment, null, props.children);
+        },
+    };
+});
+
+jest.mock('../use-base-dropdown', () => ({
+    useBaseDropdown: () => mockUseBaseDropdown(),
+}));
+
+jest.mock('../use-wallet-ui-dropdown', () => ({
+    useWalletUiDropdown: () => mockUseWalletUiDropdown(),
+}));
+
+describe('WalletUiAccountGuard', () => {
+    const cleanups: Array<() => void> = [];
+
+    afterEach(() => {
+        for (const cleanup of cleanups.splice(0).reverse()) {
+            cleanup();
+        }
+    });
+
+    it('renders the default dropdown fallback when no account is selected', () => {
+        const accountContext = createAccountContextValue({ account: undefined, wallet: undefined });
+        const dropdown = createDropdownControl();
+
+        mockUseWalletUiDropdown.mockReturnValue({
+            buttonProps: {
+                label: 'Connect Wallet',
+            },
+            connected: false,
+            dropdown,
+            items: [],
+        });
+
+        const renderer = render(
+            cleanups,
+            <WalletUiAccountContext.Provider value={accountContext}>
+                <WalletUiAccountGuard render={() => null} />
+            </WalletUiAccountContext.Provider>,
+        );
+
+        const button = renderer.root.findByProps({ 'data-wu': 'base-button' });
+
+        expect(button.children).toContain('Connect Wallet');
+    });
+
+    it('renders the account info when an account is selected', () => {
+        const account = createUiWalletAccount({ address: 'phantom-1', walletName: 'Phantom' });
+        const wallet = createUiWallet({ accounts: [account], name: 'Phantom' });
+        const accountContext = createAccountContextValue({ account, wallet });
+        const renderAccount = jest.fn(() => <span>Connected account</span>);
+
+        const renderer = render(
+            cleanups,
+            <WalletUiAccountContext.Provider value={accountContext}>
+                <WalletUiAccountGuard render={renderAccount} />
+            </WalletUiAccountContext.Provider>,
+        );
+
+        expect(renderAccount).toHaveBeenCalledWith({
+            account,
+            accountKeys: ['solana:testnet', 'Phantom:phantom-1'],
+            cluster: accountContext.cluster,
+            wallet,
+        });
+        expect(renderer.root.findByType('span').children).toEqual(['Connected account']);
+    });
+});
+
+describe('WalletUiClusterDropdown', () => {
+    const cleanups: Array<() => void> = [];
+
+    afterEach(() => {
+        for (const cleanup of cleanups.splice(0).reverse()) {
+            cleanup();
+        }
+    });
+
+    it('renders the selected cluster label and updates the cluster selection', async () => {
+        expect.assertions(4);
+
+        const dropdown = createDropdownControl();
+        const setCluster = jest.fn();
+
+        mockUseBaseDropdown.mockReturnValue(dropdown);
+
+        const renderer = render(
+            cleanups,
+            <WalletUiClusterContext.Provider
+                value={createClusterContextValue({
+                    setCluster,
+                })}
+            >
+                <WalletUiClusterDropdown buttonProps={{ className: 'cluster-trigger' }} />
+            </WalletUiClusterContext.Provider>,
+        );
+
+        const button = renderer.root.findByProps({ 'data-wu': 'base-button' });
+        const items = renderer.root.findAllByProps({ 'data-wu': 'base-dropdown-item' });
+
+        expect(button.children).toContain('Devnet');
+        expect(button.props.className).toContain('cluster-trigger');
+
+        await act(async () => {
+            items[1]?.props.onClick();
+            await Promise.resolve();
+            await Promise.resolve();
+        });
+
+        expect(setCluster).toHaveBeenCalledWith('solana:testnet');
+        expect(dropdown.close).toHaveBeenCalled();
+    });
+});
+
+describe('WalletUiDropdown', () => {
+    const cleanups: Array<() => void> = [];
+
+    afterEach(() => {
+        for (const cleanup of cleanups.splice(0).reverse()) {
+            cleanup();
+        }
+    });
+
+    it('renders the dropdown button using the wallet-ui dropdown hook output', () => {
+        const dropdown = createDropdownControl();
+
+        mockUseWalletUiDropdown.mockReturnValue({
+            buttonProps: {
+                label: 'Select Wallet',
+            },
+            connected: false,
+            dropdown,
+            items: [],
+        });
+
+        const renderer = render(cleanups, <WalletUiDropdown />);
+        const button = renderer.root.findByProps({ 'data-wu': 'base-button' });
+
+        expect(button.children).toContain('Select Wallet');
+    });
+});
+
+describe('WalletUiIcon', () => {
+    const cleanups: Array<() => void> = [];
+
+    afterEach(() => {
+        for (const cleanup of cleanups.splice(0).reverse()) {
+            cleanup();
+        }
+    });
+
+    it('renders a wallet image when wallet metadata is provided', () => {
+        const wallet = {
+            icon: TEST_ICON,
+            name: 'Phantom',
+        } satisfies Pick<UiWallet, 'icon' | 'name'>;
+        const renderer = render(cleanups, <WalletUiIcon className="wallet-icon" wallet={wallet} />);
+        const image = renderer.root.findByType('img');
+
+        expect(image.props.alt).toBe('Phantom');
+        expect(image.props.className).toBe('wallet-icon');
+        expect(image.props.src).toBe(TEST_ICON);
+    });
+
+    it('returns null when the wallet is missing', () => {
+        const renderer = render(cleanups, <WalletUiIcon />);
+
+        expect(renderer.toJSON()).toBeNull();
+    });
+});
+
+describe('WalletUiIconClose', () => {
+    const cleanups: Array<() => void> = [];
+
+    afterEach(() => {
+        for (const cleanup of cleanups.splice(0).reverse()) {
+            cleanup();
+        }
+    });
+
+    it('renders the close icon svg', () => {
+        const renderer = render(cleanups, <WalletUiIconClose className="close-icon" />);
+        const svg = renderer.root.findByType('svg');
+
+        expect(svg.props.className).toBe('close-icon');
+        expect(svg.props.viewBox).toBe('0 0 14 14');
+    });
+});
+
+describe('WalletUiIconNoWallet', () => {
+    const cleanups: Array<() => void> = [];
+
+    afterEach(() => {
+        for (const cleanup of cleanups.splice(0).reverse()) {
+            cleanup();
+        }
+    });
+
+    it('renders the no-wallet illustration svg', () => {
+        const renderer = render(cleanups, <WalletUiIconNoWallet className="no-wallet-icon" />);
+        const svg = renderer.root.findByType('svg');
+
+        expect(svg.props.className).toBe('no-wallet-icon');
+        expect(svg.props.viewBox).toBe('0 0 97 96');
+    });
+});
+
+describe('WalletUiLabel', () => {
+    const cleanups: Array<() => void> = [];
+
+    afterEach(() => {
+        for (const cleanup of cleanups.splice(0).reverse()) {
+            cleanup();
+        }
+    });
+
+    it('renders the wallet name when wallet metadata is provided', () => {
+        const wallet = createWallet({ name: 'Phantom' });
+        const renderer = render(cleanups, <WalletUiLabel className="wallet-label" wallet={wallet} />);
+        const label = renderer.root.findByProps({ 'data-wu': 'wallet-ui-label' });
+
+        expect(label.children).toEqual(['Phantom']);
+        expect(label.props.className).toBe('wallet-label');
+    });
+
+    it('returns null when the wallet is missing', () => {
+        const renderer = render(cleanups, <WalletUiLabel />);
+
+        expect(renderer.toJSON()).toBeNull();
+    });
+});
+
+describe('WalletUiList', () => {
+    const cleanups: Array<() => void> = [];
+
+    afterEach(() => {
+        for (const cleanup of cleanups.splice(0).reverse()) {
+            cleanup();
+        }
+    });
+
+    it('renders one list button per wallet', () => {
+        const phantom = createUiWallet({ name: 'Phantom' });
+        const solflare = createUiWallet({ name: 'Solflare' });
+        const renderer = render(cleanups, <WalletUiList wallets={[phantom, solflare]} />);
+
+        expect(renderer.root.findByProps({ 'data-wu': 'wallet-ui-list' })).toBeDefined();
+        expect(renderer.root.findAllByProps({ 'data-wu': 'wallet-ui-list-button' })).toHaveLength(2);
+    });
+});
+
+describe('WalletUiListButton', () => {
+    const cleanups: Array<() => void> = [];
+
+    afterEach(() => {
+        for (const cleanup of cleanups.splice(0).reverse()) {
+            cleanup();
+        }
+    });
+
+    it('is a no-op when no select handler is provided', () => {
+        const account = createUiWalletAccount({ address: 'phantom-1', walletName: 'Phantom' });
+        const renderer = render(
+            cleanups,
+            <WalletUiListButton wallet={createUiWallet({ accounts: [account], name: 'Phantom' })} />,
+        );
+        const button = renderer.root.findByProps({ 'data-wu': 'wallet-ui-list-button' });
+
+        act(() => {
+            button.props.onClick();
+        });
+
+        expect(button.props.className).not.toContain('pending');
+        expect(button.props.disabled).toBe(false);
+    });
+
+    it('sets the button to pending until the selection resolves', async () => {
+        expect.assertions(4);
+
+        const account = createUiWalletAccount({ address: 'phantom-1', walletName: 'Phantom' });
+        const deferred = createDeferred<void>();
+        const renderer = render(
+            cleanups,
+            <WalletUiListButton
+                select={jest.fn(() => deferred.promise)}
+                wallet={createUiWallet({ accounts: [account], name: 'Phantom' })}
+            />,
+        );
+
+        act(() => {
+            renderer.root.findByProps({ 'data-wu': 'wallet-ui-list-button' }).props.onClick();
+        });
+
+        expect(renderer.root.findByProps({ 'data-wu': 'wallet-ui-list-button' }).props.className).toContain('pending');
+        expect(renderer.root.findByProps({ 'data-wu': 'wallet-ui-list-button' }).props.disabled).toBe(true);
+
+        await act(async () => {
+            deferred.resolve();
+            await deferred.promise;
+        });
+
+        expect(renderer.root.findByProps({ 'data-wu': 'wallet-ui-list-button' }).props.className).not.toContain(
+            'pending',
+        );
+        expect(renderer.root.findByProps({ 'data-wu': 'wallet-ui-list-button' }).props.disabled).toBe(false);
+    });
+
+    it('clears the pending state when the selection rejects', async () => {
+        expect.assertions(4);
+
+        const account = createUiWalletAccount({ address: 'phantom-1', walletName: 'Phantom' });
+        const deferred = createDeferred<void>();
+        const select = jest.fn(() => deferred.promise.catch(() => undefined));
+        const renderer = render(
+            cleanups,
+            <WalletUiListButton
+                select={select}
+                wallet={createUiWallet({ accounts: [account], name: 'Phantom' })}
+            />,
+        );
+
+        act(() => {
+            renderer.root.findByProps({ 'data-wu': 'wallet-ui-list-button' }).props.onClick();
+        });
+
+        expect(renderer.root.findByProps({ 'data-wu': 'wallet-ui-list-button' }).props.className).toContain('pending');
+        expect(renderer.root.findByProps({ 'data-wu': 'wallet-ui-list-button' }).props.disabled).toBe(true);
+
+        await act(async () => {
+            deferred.reject(new Error('Selection failed'));
+            await Promise.resolve();
+            await Promise.resolve();
+        });
+
+        expect(renderer.root.findByProps({ 'data-wu': 'wallet-ui-list-button' }).props.className).not.toContain(
+            'pending',
+        );
+        expect(renderer.root.findByProps({ 'data-wu': 'wallet-ui-list-button' }).props.disabled).toBe(false);
+    });
+});
+
+describe('WalletUiModal', () => {
+    const cleanups: Array<() => void> = [];
+
+    afterEach(() => {
+        for (const cleanup of cleanups.splice(0).reverse()) {
+            cleanup();
+        }
+    });
+
+    it('passes the Solana wallet description to the base modal and renders the wallet list', () => {
+        const account = createUiWalletAccount({ address: 'phantom-1', walletName: 'Phantom' });
+        const modal = createModalControl();
+        const select = jest.fn();
+        const renderer = render(
+            cleanups,
+            <WalletUiModal
+                modal={modal}
+                select={select}
+                wallets={[createUiWallet({ accounts: [account], name: 'Phantom' })]}
+            />,
+        );
+
+        expect(mockBaseModal).toHaveBeenCalledTimes(1);
+        expect(mockBaseModal).toHaveBeenCalledWith(
+            expect.objectContaining({
+                description: 'Connect a wallet on Solana to continue',
+                modal,
+            }),
+        );
+        expect(renderer.root.findAllByProps({ 'data-wu': 'wallet-ui-list-button' })).toHaveLength(1);
+    });
+});
+
+describe('WalletUiModalTrigger', () => {
+    const cleanups: Array<() => void> = [];
+
+    afterEach(() => {
+        for (const cleanup of cleanups.splice(0).reverse()) {
+            cleanup();
+        }
+    });
+
+    it('opens the modal and uses the default button label', () => {
+        const modal = createModalControl();
+        const renderer = render(cleanups, <WalletUiModalTrigger modal={modal} />);
+        const button = renderer.root.findByProps({ 'data-wu': 'base-button' });
+
+        act(() => {
+            button.props.onClick();
+        });
+
+        expect(button.children).toContain('Select Wallet');
+        expect(modal.open).toHaveBeenCalled();
+    });
+});
+
+function createAccountContextValue({
+    account,
+    wallet,
+}: {
+    account: UiWalletAccount | undefined;
+    wallet: UiWallet | undefined;
+}): WalletUiAccountState {
+    return {
+        account,
+        accountKeys: account
+            ? ['solana:testnet', `${(account as unknown as { walletName: string }).walletName}:${account.address}`]
+            : [],
+        cluster: {
+            id: 'solana:testnet',
+            label: 'Testnet',
+            url: 'https://api.testnet.solana.com',
+        },
+        setAccount: jest.fn(),
+        wallet,
+    };
+}
+
+function createClusterContextValue({
+    setCluster,
+}: {
+    setCluster: jest.Mock;
+}): WalletUiClusterContextValue {
+    return {
+        cluster: {
+            id: 'solana:devnet',
+            label: 'Devnet',
+            url: 'https://api.devnet.solana.com',
+        },
+        clusters: [
+            {
+                id: 'solana:devnet',
+                label: 'Devnet',
+                url: 'https://api.devnet.solana.com',
+            },
+            {
+                id: 'solana:testnet',
+                label: 'Testnet',
+                url: 'https://api.testnet.solana.com',
+            },
+        ],
+        setCluster,
+    };
+}
+
+function createDeferred<T>() {
+    let reject!: (reason?: unknown) => void;
+    let resolve!: (value: T | PromiseLike<T>) => void;
+
+    const promise = new Promise<T>((res, rej) => {
+        reject = rej;
+        resolve = res;
+    });
+
+    return {
+        promise,
+        reject,
+        resolve,
+    };
+}
+
+function createDropdownControl() {
+    return {
+        api: {
+            getContentProps: () => ({}),
+            getIndicatorProps: () => ({}),
+            getItemProps: ({ value }: { value: string }) => ({
+                'data-value': value,
+            }),
+            getPositionerProps: () => ({}),
+            getTriggerProps: () => ({}),
+        },
+        close: jest.fn(),
+        open: jest.fn(),
+    };
+}
+
+function createModalControl() {
+    return {
+        api: {} as BaseModalControl['api'],
+        close: jest.fn(),
+        open: jest.fn(),
+    };
+}
+
+function createUiWallet({
+    accounts = [],
+    name,
+}: {
+    accounts?: UiWalletAccount[];
+    name: string;
+}): UiWallet {
+    return createWallet({
+        accounts: accounts as unknown as ReturnType<typeof createAccount>[],
+        name,
+    }) as unknown as UiWallet;
+}
+
+function createUiWalletAccount({
+    address,
+    walletName,
+}: {
+    address: string;
+    walletName: string;
+}): UiWalletAccount {
+    return createAccount({ address, walletName }) as unknown as UiWalletAccount;
+}
+
+function render(cleanups: Array<() => void>, element: React.ReactElement) {
+    let renderer!: ReturnType<typeof create>;
+
+    act(() => {
+        renderer = create(element);
+    });
+
+    cleanups.push(() => {
+        act(() => {
+            renderer.unmount();
+        });
+    });
+
+    return renderer;
+}

--- a/packages/react/src/__tests__/wallet-ui-hooks-test.tsx
+++ b/packages/react/src/__tests__/wallet-ui-hooks-test.tsx
@@ -1,0 +1,346 @@
+import type { UiWallet, UiWalletAccount } from '@wallet-standard/react';
+
+import { BaseDropdownItemType } from '../base-dropdown';
+import { renderHook } from '../test-renderer';
+import { createAccount, createWallet } from '../test-utils/wallet-ui-test-utils';
+import { useWalletUiDropdown, ellipsify } from '../use-wallet-ui-dropdown';
+import { useWalletUiSigner } from '../use-wallet-ui-signer';
+import { useWalletUiWallet } from '../use-wallet-ui-wallet';
+
+const mockUseBaseDropdown = jest.fn();
+const mockUseConnect = jest.fn();
+const mockUseDisconnect = jest.fn();
+const mockUseWalletAccountTransactionSendingSigner = jest.fn();
+const mockUseWalletUi = jest.fn();
+const mockUseWalletUiAccount = jest.fn();
+const TEST_ICON = 'data:image/png;base64,ZmFrZQ==';
+
+jest.mock('react-error-boundary', () => {
+    const React = jest.requireActual<typeof import('react')>('react');
+
+    return {
+        ErrorBoundary: ({ children }: { children: React.ReactNode }) =>
+            React.createElement(React.Fragment, null, children),
+    };
+});
+
+jest.mock('@solana/react', () => ({
+    useWalletAccountTransactionSendingSigner: (...args: unknown[]) =>
+        mockUseWalletAccountTransactionSendingSigner(...args),
+}));
+
+jest.mock('@wallet-standard/react', () => ({
+    useConnect: (...args: unknown[]) => mockUseConnect(...args),
+    useDisconnect: (...args: unknown[]) => mockUseDisconnect(...args),
+}));
+
+jest.mock('../use-base-dropdown', () => ({
+    useBaseDropdown: () => mockUseBaseDropdown(),
+}));
+
+jest.mock('../use-wallet-ui', () => ({
+    useWalletUi: () => mockUseWalletUi(),
+}));
+
+jest.mock('../use-wallet-ui-account', () => ({
+    useWalletUiAccount: () => mockUseWalletUiAccount(),
+}));
+
+describe('ellipsify', () => {
+    it('leaves short strings unchanged and truncates long strings', () => {
+        expect(ellipsify('1234567')).toBe('1234567');
+        expect(ellipsify('1234567890')).toBe('1234..7890');
+    });
+});
+
+describe('useWalletUiDropdown', () => {
+    it('builds connect items for disconnected wallets', async () => {
+        expect.assertions(7);
+
+        const account = createUiWalletAccount({ address: 'phantom-1', walletName: 'Phantom' });
+        const connect = jest.fn();
+        const dropdown = createDropdownControl();
+        const wallet = createUiWallet({ accounts: [account], name: 'Phantom' });
+
+        mockUseBaseDropdown.mockReturnValue(dropdown);
+        mockUseWalletUi.mockReturnValue({
+            account: undefined,
+            connect,
+            connected: false,
+            copy: jest.fn(),
+            disconnect: jest.fn(),
+            wallet: undefined,
+            wallets: [wallet],
+        });
+
+        const hook = getHookResult(renderHook(() => useWalletUiDropdown()).result);
+
+        expect(hook.buttonProps.label).toBe('Select Wallet');
+        expect(hook.buttonProps.leftSection).toBeUndefined();
+        expect(hook.connected).toBe(false);
+        expect(hook.dropdown).toBe(dropdown);
+        expect(hook.items.map(item => item.label)).toEqual(['Phantom']);
+        expect(hook.items[0]?.type).toBe(BaseDropdownItemType.WalletConnect);
+
+        await hook.items[0]?.handler();
+
+        expect(connect).toHaveBeenCalledWith(account);
+    });
+
+    it('falls back to the wallet-needed action when no wallets are available', async () => {
+        expect.assertions(3);
+
+        const dropdown = createDropdownControl();
+        const open = jest.fn();
+        const restoreWindow = stubWindowOpen(open);
+
+        mockUseBaseDropdown.mockReturnValue(dropdown);
+        mockUseWalletUi.mockReturnValue({
+            account: undefined,
+            connect: jest.fn(),
+            connected: false,
+            copy: jest.fn(),
+            disconnect: jest.fn(),
+            wallet: undefined,
+            wallets: [],
+        });
+
+        try {
+            const hook = getHookResult(renderHook(() => useWalletUiDropdown()).result);
+
+            expect(hook.items.map(item => item.label)).toEqual(["You'll need a wallet on Solana to continue"]);
+            expect(hook.items[0]?.type).toBe(BaseDropdownItemType.WalletNeeded);
+
+            await hook.items[0]?.handler();
+
+            expect(open).toHaveBeenCalledWith('https://solana.com/solana-wallets', '_blank');
+        } finally {
+            restoreWindow();
+        }
+    });
+
+    it('builds copy and disconnect actions for connected wallets', async () => {
+        expect.assertions(5);
+
+        const account = createUiWalletAccount({ address: '1234567890', walletName: 'Phantom' });
+        const copy = jest.fn();
+        const disconnect = jest.fn();
+        const dropdown = createDropdownControl();
+        const wallet = createUiWallet({ accounts: [account], icon: TEST_ICON, name: 'Phantom' });
+
+        mockUseBaseDropdown.mockReturnValue(dropdown);
+        mockUseWalletUi.mockReturnValue({
+            account,
+            connect: jest.fn(),
+            connected: true,
+            copy,
+            disconnect,
+            wallet,
+            wallets: [wallet],
+        });
+
+        const hook = getHookResult(renderHook(() => useWalletUiDropdown()).result);
+
+        expect(hook.buttonProps.label).toBe('1234..7890');
+        expect(hook.items.map(item => item.label)).toEqual(['Copy Address', 'Disconnect', 'Phantom']);
+
+        await hook.items[0]?.handler();
+        await hook.items[1]?.handler();
+
+        expect(copy).toHaveBeenCalled();
+        expect(disconnect).toHaveBeenCalled();
+        expect(dropdown.close).toHaveBeenCalled();
+    });
+
+    it('falls back to the wallet name and connected label when the account is missing', () => {
+        expect.assertions(2);
+
+        const dropdown = createDropdownControl();
+        const wallet = createUiWallet({ accounts: [], icon: TEST_ICON, name: 'Phantom' });
+
+        mockUseBaseDropdown.mockReturnValue(dropdown);
+        mockUseWalletUi
+            .mockReturnValueOnce({
+                account: undefined,
+                connect: jest.fn(),
+                connected: true,
+                copy: jest.fn(),
+                disconnect: jest.fn(),
+                wallet,
+                wallets: [wallet],
+            })
+            .mockReturnValueOnce({
+                account: undefined,
+                connect: jest.fn(),
+                connected: true,
+                copy: jest.fn(),
+                disconnect: jest.fn(),
+                wallet: undefined,
+                wallets: [],
+            });
+
+        const hook = renderHook(() => useWalletUiDropdown());
+
+        expect(getHookResult(hook.result).buttonProps.label).toBe('Phantom');
+
+        hook.rerenderHook(() => useWalletUiDropdown());
+
+        expect(getHookResult(hook.result).buttonProps.label).toBe('Connected');
+    });
+});
+
+describe('useWalletUiSigner', () => {
+    it('delegates to the Solana signer hook with the selected cluster id', () => {
+        const account = createAccount({ address: 'phantom-1', walletName: 'Phantom' }) as unknown as UiWalletAccount;
+        const signer = { send: jest.fn() };
+
+        mockUseWalletAccountTransactionSendingSigner.mockReturnValue(signer);
+        mockUseWalletUi.mockReturnValue({
+            cluster: {
+                id: 'solana:testnet',
+            },
+        });
+
+        const hook = renderHook(() => useWalletUiSigner({ account }));
+
+        expect(hook.result.current).toBe(signer);
+        expect(mockUseWalletAccountTransactionSendingSigner).toHaveBeenCalledWith(account, 'solana:testnet');
+    });
+});
+
+describe('useWalletUiWallet', () => {
+    it('connects the first account and exposes the wallet loading state', async () => {
+        expect.assertions(6);
+
+        const account = createUiWalletAccount({ address: 'phantom-1', walletName: 'Phantom' });
+        const connect = jest.fn().mockResolvedValue([account]);
+        const connectAccount = jest.fn();
+        const disconnect = jest.fn().mockResolvedValue(undefined);
+        const setAccount = jest.fn();
+        const wallet = createUiWallet({ accounts: [account], name: 'Phantom' });
+
+        mockUseConnect.mockReturnValue([true, connect]);
+        mockUseDisconnect.mockReturnValue([false, disconnect]);
+        mockUseWalletUi.mockReturnValue({ connect: connectAccount });
+        mockUseWalletUiAccount.mockReturnValue({ setAccount });
+
+        const hook = getHookResult(renderHook(() => useWalletUiWallet({ wallet })).result);
+
+        expect(hook.isConnecting).toBe(true);
+        expect(hook.isDisconnecting).toBe(false);
+
+        await expect(hook.connect()).resolves.toEqual([account]);
+        await hook.disconnect();
+
+        expect(setAccount).toHaveBeenCalledWith(account);
+        expect(connectAccount).toHaveBeenCalledWith(account);
+        expect(disconnect).toHaveBeenCalled();
+    });
+
+    it('warns and skips account selection when connect returns no accounts', async () => {
+        expect.assertions(6);
+
+        const connect = jest.fn().mockResolvedValue([]);
+        const connectAccount = jest.fn();
+        const disconnect = jest.fn();
+        const setAccount = jest.fn();
+        const wallet = createUiWallet({ accounts: [], name: 'Phantom' });
+
+        mockUseConnect.mockReturnValue([false, connect]);
+        mockUseDisconnect.mockReturnValue([true, disconnect]);
+        mockUseWalletUi.mockReturnValue({ connect: connectAccount });
+        mockUseWalletUiAccount.mockReturnValue({ setAccount });
+
+        const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+        try {
+            const hook = getHookResult(renderHook(() => useWalletUiWallet({ wallet })).result);
+
+            expect(hook.isConnecting).toBe(false);
+            expect(hook.isDisconnecting).toBe(true);
+
+            await expect(hook.connect()).resolves.toEqual([]);
+
+            expect(warn).toHaveBeenCalledWith('Connect to Phantom but there are no accounts.');
+            expect(connectAccount).not.toHaveBeenCalled();
+            expect(setAccount).not.toHaveBeenCalled();
+        } finally {
+            warn.mockRestore();
+        }
+    });
+});
+
+function createDropdownControl() {
+    return {
+        api: {},
+        close: jest.fn(),
+        open: jest.fn(),
+    };
+}
+
+function stubWindowOpen(open: jest.Mock) {
+    if (typeof window !== 'undefined') {
+        const spy = jest.spyOn(window, 'open').mockImplementation(((...args) => {
+            open(...args);
+            return null;
+        }) as typeof window.open);
+
+        return () => {
+            spy.mockRestore();
+        };
+    }
+
+    const descriptor = Object.getOwnPropertyDescriptor(globalThis, 'window');
+
+    Object.defineProperty(globalThis, 'window', {
+        configurable: true,
+        value: {
+            open,
+        },
+    });
+
+    return () => {
+        if (descriptor) {
+            Object.defineProperty(globalThis, 'window', descriptor);
+        } else {
+            Reflect.deleteProperty(globalThis, 'window');
+        }
+    };
+}
+
+function createUiWallet({
+    accounts = [],
+    icon,
+    name,
+}: {
+    accounts?: UiWalletAccount[];
+    icon?: UiWallet['icon'];
+    name: string;
+}): UiWallet {
+    return {
+        ...(createWallet({
+            accounts: accounts as unknown as ReturnType<typeof createAccount>[],
+            name,
+        }) as unknown as UiWallet),
+        ...(icon ? { icon } : {}),
+    };
+}
+
+function createUiWalletAccount({
+    address,
+    walletName,
+}: {
+    address: string;
+    walletName: string;
+}): UiWalletAccount {
+    return createAccount({ address, walletName }) as unknown as UiWalletAccount;
+}
+
+function getHookResult<T>(result: { __type: 'error'; current: Error } | { __type: 'result'; current?: T }): T {
+    if (result.__type === 'error') {
+        throw result.current;
+    }
+    if (result.current === undefined) {
+        throw new Error('Missing hook result');
+    }
+    return result.current;
+}

--- a/packages/react/src/__tests__/wallet-ui-test.tsx
+++ b/packages/react/src/__tests__/wallet-ui-test.tsx
@@ -9,6 +9,7 @@ import {
     type TestWallet,
 } from '../test-utils/wallet-ui-test-utils';
 import { useWalletUi } from '../use-wallet-ui';
+import { createWalletUiConfig } from '../wallet-ui';
 import { WalletUi } from '../wallet-ui';
 
 const CLUSTERS: SolanaCluster[] = [
@@ -51,6 +52,16 @@ describe('WalletUi', () => {
         }
         jest.runOnlyPendingTimers();
         jest.useRealTimers();
+    });
+
+    it('returns the provided wallet-ui config unchanged', () => {
+        const config = createWalletUiConfig({
+            clusters: CLUSTERS,
+        });
+
+        expect(config).toEqual({
+            clusters: CLUSTERS,
+        });
     });
 
     it('restores stored provider state and clears the selected account on disconnect', () => {


### PR DESCRIPTION
Add targeted tests for wallet-ui hooks and wallet-ui-named components that were still low or empty in the published package coverage report.

Cover the remaining WalletUi config helper line in the composed WalletUi test and keep the change scoped to @wallet-ui/react tests only.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wallet-ui/wallet-ui/pull/487" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive tests for wallet UI components: account guard fallback/rendering, cluster dropdown selection, dropdown labels, icons/labels conditional rendering, wallet list/button behaviors (including async pending/disabled state), modal content/controls, and trigger actions.
  * Added hook tests: string ellipsify, dropdown item flows (connect, copy address, disconnect, open wallets page), signer delegation, and connection/disconnection edge cases (including empty-account warning).
  * Added config validation test for wallet UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->