### PR TITLE
fix: breaking build on Cloudflare Workers

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,9 +62,7 @@
     },
     "engines": {
         "node": ">=20.18.0",
-        "npm": "please-use-pnpm",
-        "pnpm": "^10",
-        "yarn": "please-use-pnpm"
+        "pnpm": "^10"
     },
     "packageManager": "pnpm@10.33.0",
     "pnpm": {


### PR DESCRIPTION
Somehow, an undocumented change over at Cloudflare broke the build. Apparently related to the `please-use-pnpm` option. This has worked fine for quite some time, but today it broke the build 🤷‍♂️

<img width="1203" height="602" alt="image" src="https://github.com/user-attachments/assets/86ed5530-872a-46ce-8bae-7c5f22782206" />

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wallet-ui/wallet-ui/pull/493" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined package manager configuration to exclusively require pnpm (version 10 or higher), removing previous constraints that discouraged the use of npm and yarn.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->