### PR TITLE
ci: update Dependabot schedule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,16 +8,25 @@ updates:
   - package-ecosystem: 'npm'
     directory: '/'
     schedule:
-      interval: daily
-      time: '01:00'
-      timezone: America/Los_Angeles
+      day: 'monday'
+      interval: 'weekly'
     labels:
       - 'automerge'
-    ignore:
-      - dependency-name: '@radix-ui/react-dropdown-menu'
     groups:
       eslint:
         patterns:
           - '@eslint/*'
           - '@typescript-eslint/*'
           - 'typescript'
+
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      day: 'monday'
+      interval: 'weekly'
+    labels:
+      - 'automerge'
+    groups:
+      github-actions:
+        patterns:
+          - '*'


### PR DESCRIPTION
Run npm dependency updates weekly on Mondays instead of daily.

Add weekly Dependabot updates for GitHub Actions workflows, group those action updates together, and remove the stale Radix dropdown-menu ignore.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wallet-ui/wallet-ui/pull/496" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Switched dependency update automation to run weekly on Mondays.
  * Re-enabled automated updates for a previously excluded dependency.
  * Added automated weekly updates for GitHub Actions with auto-merge and grouped updates for related actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
