### PR TITLE
fix(react): guard stale wallet dropdown handles

### DIFF
--- a/.changeset/guard-stale-wallet-dropdown-handles.md
+++ b/.changeset/guard-stale-wallet-dropdown-handles.md
@@ -1,0 +1,5 @@
+---
+"@wallet-ui/react": patch
+---
+
+Guard `WalletUiDropdown` against stale wallet handles and document correct `UiWallet` usage.

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -53,6 +53,16 @@ function YourApp() {
 }
 ```
 
+## Wallet Handles
+
+`UiWallet` values are opaque handles created by Wallet Standard and wallet-ui internals. Do not create, persist, replay, or
+inject your own `UiWallet` objects into wallet-ui context. Wrap your app with `<WalletUi>` and let wallet-ui source the
+wallet list from Wallet Standard.
+
+If you build a custom selector, consume wallets returned by wallet-ui hooks/components as opaque values and pass them back
+to wallet-ui APIs. A wallet handle can become unavailable when a browser extension unregisters or changes state; the
+prebuilt dropdown treats those stale handles as unavailable instead of crashing the render tree.
+
 ## Documentation
 
 For full documentation, including guides, component references, and hook APIs, please

--- a/packages/react/src/__tests__/wallet-ui-components-test.tsx
+++ b/packages/react/src/__tests__/wallet-ui-components-test.tsx
@@ -1,6 +1,7 @@
 import type { UiWallet, UiWalletAccount } from '@wallet-standard/react';
 import React from 'react';
 import { act, create } from 'react-test-renderer';
+import { BaseDropdownItemType } from '../base-dropdown';
 import type { BaseModalProps } from '../base-modal';
 import type { BaseModalControl } from '../use-base-modal';
 
@@ -21,12 +22,14 @@ import { createAccount, createWallet } from '../test-utils/wallet-ui-test-utils'
 
 const mockBaseModal = jest.fn();
 const mockUseBaseDropdown = jest.fn();
+const mockUseWalletUiWallet = jest.fn();
 const mockUseWalletUiDropdown = jest.fn();
 const TEST_ICON = 'data:image/png;base64,ZmFrZQ==';
 
 afterEach(() => {
     mockBaseModal.mockReset();
     mockUseBaseDropdown.mockReset();
+    mockUseWalletUiWallet.mockReset();
     mockUseWalletUiDropdown.mockReset();
 });
 
@@ -47,6 +50,10 @@ jest.mock('../use-base-dropdown', () => ({
 
 jest.mock('../use-wallet-ui-dropdown', () => ({
     useWalletUiDropdown: () => mockUseWalletUiDropdown(),
+}));
+
+jest.mock('../use-wallet-ui-wallet', () => ({
+    useWalletUiWallet: (options: unknown) => mockUseWalletUiWallet(options),
 }));
 
 describe('WalletUiAccountGuard', () => {
@@ -176,6 +183,102 @@ describe('WalletUiDropdown', () => {
         const button = renderer.root.findByProps({ 'data-wu': 'base-button' });
 
         expect(button.children).toContain('Select Wallet');
+    });
+
+    it('renders disabled wallet items without mounting wallet hooks', () => {
+        const dropdown = createDropdownControl();
+        const wallet = createUiWallet({ name: 'Phantom' });
+
+        mockUseWalletUiWallet.mockImplementation(() => {
+            throw new Error('Disabled wallet items must not mount wallet hooks');
+        });
+        mockUseWalletUiDropdown.mockReturnValue({
+            buttonProps: {
+                label: 'Select Wallet',
+            },
+            connected: false,
+            dropdown,
+            items: [
+                {
+                    disabled: true,
+                    handler: jest.fn(),
+                    label: 'Phantom',
+                    type: BaseDropdownItemType.WalletConnect,
+                    value: 'phantom',
+                    wallet,
+                },
+            ],
+        });
+
+        const renderer = render(cleanups, <WalletUiDropdown />);
+        const item = renderer.root.findByProps({ 'data-wu': 'base-dropdown-item' });
+
+        expect(item.props.disabled).toBe(true);
+        expect(item.props['aria-disabled']).toBe(true);
+        expect(item.children).toContain('Phantom');
+        expect(mockUseWalletUiWallet).not.toHaveBeenCalled();
+    });
+
+    it('mounts wallet hooks for enabled wallet items', async () => {
+        expect.assertions(7);
+
+        const connect = jest.fn().mockResolvedValue(undefined);
+        const disconnect = jest.fn().mockResolvedValue(undefined);
+        const dropdown = createDropdownControl();
+        const onConnect = jest.fn().mockResolvedValue(undefined);
+        const onDisconnect = jest.fn().mockResolvedValue(undefined);
+        const wallet = createUiWallet({ name: 'Phantom' });
+
+        mockUseWalletUiWallet.mockReturnValue({
+            connect,
+            disconnect,
+        });
+        mockUseWalletUiDropdown.mockReturnValue({
+            buttonProps: {
+                label: 'Select Wallet',
+            },
+            connected: false,
+            dropdown,
+            items: [
+                {
+                    handler: onConnect,
+                    label: 'Connect Phantom',
+                    type: BaseDropdownItemType.WalletConnect,
+                    value: 'connect',
+                    wallet,
+                },
+                {
+                    handler: onDisconnect,
+                    label: 'Disconnect Phantom',
+                    type: BaseDropdownItemType.WalletDisconnect,
+                    value: 'disconnect',
+                    wallet,
+                },
+            ],
+        });
+
+        const renderer = render(cleanups, <WalletUiDropdown />);
+        const items = renderer.root.findAllByProps({ 'data-wu': 'base-dropdown-item' });
+
+        expect(mockUseWalletUiWallet).toHaveBeenCalledTimes(2);
+
+        await act(async () => {
+            items[0]?.props.onClick({ defaultPrevented: false });
+            await Promise.resolve();
+            await Promise.resolve();
+        });
+        await act(async () => {
+            items[1]?.props.onClick({ defaultPrevented: false });
+            await Promise.resolve();
+            await Promise.resolve();
+        });
+
+        expect(connect).toHaveBeenCalled();
+        expect(onConnect).toHaveBeenCalled();
+        expect(disconnect).toHaveBeenCalled();
+        expect(onDisconnect).toHaveBeenCalled();
+        expect(dropdown.close).toHaveBeenCalledTimes(2);
+        expect(dropdown.api.getItemProps).toHaveBeenCalledWith({ disabled: undefined, value: 'connect' });
     });
 });
 
@@ -504,9 +607,10 @@ function createDropdownControl() {
         api: {
             getContentProps: () => ({}),
             getIndicatorProps: () => ({}),
-            getItemProps: ({ value }: { value: string }) => ({
+            getItemProps: jest.fn(({ disabled, value }: { disabled?: boolean; value: string }) => ({
+                'aria-disabled': disabled,
                 'data-value': value,
-            }),
+            })),
             getPositionerProps: () => ({}),
             getTriggerProps: () => ({}),
         },

--- a/packages/react/src/__tests__/wallet-ui-hooks-test.tsx
+++ b/packages/react/src/__tests__/wallet-ui-hooks-test.tsx
@@ -1,3 +1,4 @@
+import { StandardConnect, StandardDisconnect } from '@wallet-standard/core';
 import type { UiWallet, UiWalletAccount } from '@wallet-standard/react';
 
 import { BaseDropdownItemType } from '../base-dropdown';
@@ -13,7 +14,13 @@ const mockUseDisconnect = jest.fn();
 const mockUseWalletAccountTransactionSendingSigner = jest.fn();
 const mockUseWalletUi = jest.fn();
 const mockUseWalletUiAccount = jest.fn();
+const mockGetWalletFeature = jest.fn((_wallet?: unknown, _featureName?: unknown) => ({}));
 const TEST_ICON = 'data:image/png;base64,ZmFrZQ==';
+
+afterEach(() => {
+    mockGetWalletFeature.mockReset();
+    mockGetWalletFeature.mockImplementation(() => ({}));
+});
 
 jest.mock('react-error-boundary', () => {
     const React = jest.requireActual<typeof import('react')>('react');
@@ -32,6 +39,10 @@ jest.mock('@solana/react', () => ({
 jest.mock('@wallet-standard/react', () => ({
     useConnect: (...args: unknown[]) => mockUseConnect(...args),
     useDisconnect: (...args: unknown[]) => mockUseDisconnect(...args),
+}));
+
+jest.mock('@wallet-standard/ui', () => ({
+    getWalletFeature: (wallet: unknown, featureName: unknown) => mockGetWalletFeature(wallet, featureName),
 }));
 
 jest.mock('../use-base-dropdown', () => ({
@@ -119,6 +130,66 @@ describe('useWalletUiDropdown', () => {
         }
     });
 
+    it('marks unavailable wallets as disabled connect items', async () => {
+        expect.assertions(6);
+
+        const connect = jest.fn();
+        const dropdown = createDropdownControl();
+        const wallet = createUiWallet({ name: 'Phantom' });
+
+        mockGetWalletFeature.mockImplementationOnce(() => {
+            throw new Error('stale wallet handle');
+        });
+        mockUseBaseDropdown.mockReturnValue(dropdown);
+        mockUseWalletUi.mockReturnValue({
+            account: undefined,
+            connect,
+            connected: false,
+            copy: jest.fn(),
+            disconnect: jest.fn(),
+            wallet: undefined,
+            wallets: [wallet],
+        });
+
+        const hook = getHookResult(renderHook(() => useWalletUiDropdown()).result);
+
+        expect(mockGetWalletFeature).toHaveBeenCalledWith(wallet, StandardConnect);
+        expect(hook.items.map(item => item.label)).toEqual(['Phantom']);
+        expect(hook.items[0]?.disabled).toBe(true);
+        expect(hook.items[0]?.rightSection).toBe('Unavailable');
+
+        await hook.items[0]?.handler();
+
+        expect(connect).not.toHaveBeenCalled();
+        expect(hook.items[0]?.type).toBe(BaseDropdownItemType.Item);
+    });
+
+    it('does not select an available wallet when it has no accounts', async () => {
+        expect.assertions(2);
+
+        const connect = jest.fn();
+        const dropdown = createDropdownControl();
+        const wallet = createUiWallet({ name: 'Phantom' });
+
+        mockUseBaseDropdown.mockReturnValue(dropdown);
+        mockUseWalletUi.mockReturnValue({
+            account: undefined,
+            connect,
+            connected: false,
+            copy: jest.fn(),
+            disconnect: jest.fn(),
+            wallet: undefined,
+            wallets: [wallet],
+        });
+
+        const hook = getHookResult(renderHook(() => useWalletUiDropdown()).result);
+
+        await hook.items[0]?.handler();
+
+        expect(hook.items[0]?.type).toBe(BaseDropdownItemType.WalletConnect);
+        expect(connect).not.toHaveBeenCalled();
+    });
+
     it('builds copy and disconnect actions for connected wallets', async () => {
         expect.assertions(5);
 
@@ -148,6 +219,39 @@ describe('useWalletUiDropdown', () => {
         await hook.items[1]?.handler();
 
         expect(copy).toHaveBeenCalled();
+        expect(disconnect).toHaveBeenCalled();
+        expect(dropdown.close).toHaveBeenCalled();
+    });
+
+    it('clears connected state without wallet hooks when the selected wallet is unavailable', async () => {
+        expect.assertions(5);
+
+        const disconnect = jest.fn();
+        const dropdown = createDropdownControl();
+        const wallet = createUiWallet({ icon: TEST_ICON, name: 'Phantom' });
+
+        mockGetWalletFeature.mockImplementation(() => {
+            throw new Error('stale wallet handle');
+        });
+        mockUseBaseDropdown.mockReturnValue(dropdown);
+        mockUseWalletUi.mockReturnValue({
+            account: undefined,
+            connect: jest.fn(),
+            connected: true,
+            copy: jest.fn(),
+            disconnect,
+            wallet,
+            wallets: [wallet],
+        });
+
+        const hook = getHookResult(renderHook(() => useWalletUiDropdown()).result);
+
+        expect(mockGetWalletFeature).toHaveBeenCalledWith(wallet, StandardConnect);
+        expect(mockGetWalletFeature).not.toHaveBeenCalledWith(wallet, StandardDisconnect);
+        expect(hook.items[1]?.type).toBe(BaseDropdownItemType.Item);
+
+        await hook.items[1]?.handler();
+
         expect(disconnect).toHaveBeenCalled();
         expect(dropdown.close).toHaveBeenCalled();
     });

--- a/packages/react/src/base-dropdown.tsx
+++ b/packages/react/src/base-dropdown.tsx
@@ -55,19 +55,18 @@ export function BaseDropdown({ buttonProps, dropdown, items, showIndicator }: Ba
             <div {...api.getPositionerProps()} data-wu="base-dropdown-wrapper">
                 <div {...api.getContentProps()} data-wu="base-dropdown-list" data-part="content">
                     {items.map(item => {
+                        const itemProps = api.getItemProps({ disabled: item.disabled, value: item.value });
+
                         return (
                             <BaseDropdownItem
-                                {...api.getItemProps({ value: item.value })}
                                 key={item.value}
-                                item={item}
                                 afterClick={() => {
-                                    if (item.disabled) {
-                                        return;
-                                    }
                                     if (item.closeMenu !== false) {
                                         dropdown.close();
                                     }
                                 }}
+                                item={item}
+                                itemProps={itemProps}
                             />
                         );
                     })}
@@ -77,25 +76,40 @@ export function BaseDropdown({ buttonProps, dropdown, items, showIndicator }: Ba
     );
 }
 
-function BaseDropdownItem({ afterClick, item }: BaseDropdownItemRenderProps) {
-    if (!item.wallet) {
-        return <BaseDropdownItemRender afterClick={afterClick} item={item} />;
+function BaseDropdownItem({ afterClick, item, itemProps }: BaseDropdownItemRenderProps) {
+    if (!item.wallet || item.disabled) {
+        return <BaseDropdownItemRender afterClick={afterClick} item={item} itemProps={itemProps} />;
     }
     switch (item.type) {
         case BaseDropdownItemType.Item:
-            return <BaseDropdownItemRender afterClick={afterClick} item={item} />;
+            return <BaseDropdownItemRender afterClick={afterClick} item={item} itemProps={itemProps} />;
         case BaseDropdownItemType.WalletConnect:
-            return <BaseDropdownItemWalletConnect afterClick={afterClick} item={item} wallet={item.wallet} />;
+            return (
+                <BaseDropdownItemWalletConnect
+                    afterClick={afterClick}
+                    item={item}
+                    itemProps={itemProps}
+                    wallet={item.wallet}
+                />
+            );
         case BaseDropdownItemType.WalletCopy:
-            return <BaseDropdownItemRender afterClick={afterClick} item={item} />;
+            return <BaseDropdownItemRender afterClick={afterClick} item={item} itemProps={itemProps} />;
         case BaseDropdownItemType.WalletDisconnect:
-            return <BaseDropdownItemWalletDisconnect afterClick={afterClick} item={item} wallet={item.wallet} />;
+            return (
+                <BaseDropdownItemWalletDisconnect
+                    afterClick={afterClick}
+                    item={item}
+                    itemProps={itemProps}
+                    wallet={item.wallet}
+                />
+            );
     }
 }
 
 function BaseDropdownItemWalletConnect({
     afterClick,
     item,
+    itemProps,
     wallet,
 }: BaseDropdownItemRenderProps & {
     wallet: UiWallet;
@@ -113,6 +127,7 @@ function BaseDropdownItemWalletConnect({
                 },
                 leftSection: wallet ? <WalletUiIcon wallet={wallet} /> : undefined,
             }}
+            itemProps={itemProps}
         />
     );
 }
@@ -120,6 +135,7 @@ function BaseDropdownItemWalletConnect({
 function BaseDropdownItemWalletDisconnect({
     afterClick,
     item,
+    itemProps,
     wallet,
 }: BaseDropdownItemRenderProps & {
     wallet: UiWallet;
@@ -136,6 +152,7 @@ function BaseDropdownItemWalletDisconnect({
                     return await item.handler();
                 },
             }}
+            itemProps={itemProps}
         />
     );
 }
@@ -143,10 +160,21 @@ function BaseDropdownItemWalletDisconnect({
 interface BaseDropdownItemRenderProps {
     afterClick: () => void;
     item: BaseDropdownItem;
+    itemProps: BaseDropdownItemProps;
 }
 
-function BaseDropdownItemRender({ afterClick, item }: BaseDropdownItemRenderProps) {
-    function onClick() {
+type BaseDropdownItemProps = ReturnType<BaseDropdownControl['api']['getItemProps']>;
+
+function BaseDropdownItemRender({ afterClick, item, itemProps }: BaseDropdownItemRenderProps) {
+    const { onClick: onItemClick, ...buttonProps } = itemProps;
+
+    function onClick(event?: React.MouseEvent<HTMLButtonElement>) {
+        if (event) {
+            onItemClick?.(event);
+            if (event.defaultPrevented) {
+                return;
+            }
+        }
         if (item.disabled) {
             return;
         }
@@ -156,7 +184,14 @@ function BaseDropdownItemRender({ afterClick, item }: BaseDropdownItemRenderProp
     }
 
     return (
-        <button type="button" data-wu="base-dropdown-item" data-part="item" onClick={onClick}>
+        <button
+            {...buttonProps}
+            disabled={item.disabled}
+            type="button"
+            data-wu="base-dropdown-item"
+            data-part="item"
+            onClick={onClick}
+        >
             {item.leftSection ? <span data-wu="base-dropdown-item-left-section">{item.leftSection}</span> : null}
             {item.label}
             {item.rightSection ? <span data-wu="base-dropdown-item-right-section">{item.rightSection}</span> : null}

--- a/packages/react/src/use-wallet-ui-dropdown.tsx
+++ b/packages/react/src/use-wallet-ui-dropdown.tsx
@@ -1,4 +1,6 @@
+import { StandardConnect, StandardDisconnect } from '@wallet-standard/core';
 import { UiWallet, UiWalletAccount } from '@wallet-standard/react';
+import { getWalletFeature } from '@wallet-standard/ui';
 import React, { useMemo } from 'react';
 
 import { BaseButtonProps } from './base-button';
@@ -6,6 +8,20 @@ import { BaseDropdownItem, BaseDropdownItemType } from './base-dropdown';
 import { BaseDropdownControl, useBaseDropdown } from './use-base-dropdown';
 import { useWalletUi } from './use-wallet-ui';
 import { WalletUiIcon } from './wallet-ui-icon';
+
+function createWalletUnavailableItem(wallet: UiWallet): BaseDropdownItem {
+    return {
+        disabled: true,
+        handler: async () => {
+            await Promise.resolve();
+        },
+        label: wallet.name,
+        leftSection: <WalletUiIcon wallet={wallet} />,
+        rightSection: 'Unavailable',
+        type: BaseDropdownItemType.Item,
+        value: wallet.name,
+    };
+}
 
 function getDropdownItemsWallets({
     wallets,
@@ -15,22 +31,26 @@ function getDropdownItemsWallets({
     wallets: UiWallet[];
 }): BaseDropdownItem[] {
     return wallets.length
-        ? wallets.map(wallet => ({
-              handler: async () => {
-                  // TODO: Add support for multiple accounts, properly handle no accounts
-                  const account = wallet.accounts.length > 0 ? wallet.accounts[0] : undefined;
-                  if (!account) {
-                      return;
-                  }
-                  connect(account);
-                  await Promise.resolve();
-              },
-              label: wallet.name,
+        ? wallets.map(wallet =>
+              isWalletFeatureAvailable(wallet, StandardConnect)
+                  ? {
+                        handler: async () => {
+                            // TODO: Add support for multiple accounts, properly handle no accounts
+                            const account = wallet.accounts.length > 0 ? wallet.accounts[0] : undefined;
+                            if (!account) {
+                                return;
+                            }
+                            connect(account);
+                            await Promise.resolve();
+                        },
+                        label: wallet.name,
 
-              type: BaseDropdownItemType.WalletConnect,
-              value: wallet.name,
-              wallet,
-          }))
+                        type: BaseDropdownItemType.WalletConnect,
+                        value: wallet.name,
+                        wallet,
+                    }
+                  : createWalletUnavailableItem(wallet),
+          )
         : [
               {
                   handler: async () => {
@@ -57,29 +77,34 @@ export function useWalletUiDropdown(): {
     const itemsWallets = useMemo(() => getDropdownItemsWallets({ connect, wallets }), [wallets, connect]);
 
     const itemsConnected: BaseDropdownItem[] = useMemo(
-        () => [
-            {
-                handler: async () => {
-                    copy();
-                    void (await Promise.resolve());
+        () => {
+            const walletCanDisconnect =
+                isWalletFeatureAvailable(wallet, StandardConnect) && isWalletFeatureAvailable(wallet, StandardDisconnect);
+
+            return [
+                {
+                    handler: async () => {
+                        copy();
+                        void (await Promise.resolve());
+                    },
+                    label: 'Copy Address',
+                    type: BaseDropdownItemType.WalletCopy,
+                    value: 'copy',
                 },
-                label: 'Copy Address',
-                type: BaseDropdownItemType.WalletCopy,
-                value: 'copy',
-            },
-            {
-                handler: async () => {
-                    disconnect();
-                    dropdown.close();
-                    await Promise.resolve();
+                {
+                    handler: async () => {
+                        disconnect();
+                        dropdown.close();
+                        await Promise.resolve();
+                    },
+                    label: 'Disconnect',
+                    type: walletCanDisconnect ? BaseDropdownItemType.WalletDisconnect : BaseDropdownItemType.Item,
+                    value: 'disconnect',
+                    wallet: walletCanDisconnect ? wallet : undefined,
                 },
-                label: 'Disconnect',
-                type: BaseDropdownItemType.WalletDisconnect,
-                value: 'disconnect',
-                wallet,
-            },
-            ...itemsWallets,
-        ],
+                ...itemsWallets,
+            ];
+        },
         [copy, disconnect, dropdown, wallet, itemsWallets],
     );
     const items = useMemo(() => {
@@ -106,4 +131,16 @@ export function ellipsify(str = '', len = 4, delimiter = '..') {
     const limit = len * 2 + delimiter.length;
 
     return strLen >= limit ? str.substring(0, len) + delimiter + str.substring(strLen - len, strLen) : str;
+}
+
+function isWalletFeatureAvailable(wallet: UiWallet | undefined, featureName: UiWallet['features'][number]) {
+    if (!wallet) {
+        return false;
+    }
+    try {
+        getWalletFeature(wallet, featureName);
+        return true;
+    } catch {
+        return false;
+    }
 }


### PR DESCRIPTION
Resolve wallet handles before rendering hook-backed dropdown items so stale handles render as unavailable instead of crashing during render.

Thread disabled state through Zag menu item props, keep stale connected wallets clearable without wallet hooks, and document that UiWallet values are opaque Wallet Standard handles.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Wallet dropdown now gracefully handles stale/unavailable wallet handles by displaying them as disabled items instead of crashing.

* **Bug Fixes**
  * Prevents crashes when wallet connections become unavailable during browser extension state changes.

* **Documentation**
  * Added guidance on proper wallet handle usage and lifecycle to prevent issues with stale wallet references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->