### PR TITLE
feat(react-native): expose unsupported iOS wallet state

### DIFF
--- a/.changeset/expose-react-native-ios-wallet-state.md
+++ b/.changeset/expose-react-native-ios-wallet-state.md
@@ -1,0 +1,6 @@
+---
+"@wallet-ui/react-native-kit": major
+"@wallet-ui/react-native-web3js": major
+---
+
+Expose Android Mobile Wallet Adapter through the `./android` subpath and return unsupported wallet metadata on iOS instead of loading Android wallet transport from the root package entrypoint.

--- a/docs/src/content/docs/react-native/core-concepts.mdx
+++ b/docs/src/content/docs/react-native/core-concepts.mdx
@@ -5,7 +5,7 @@ description: Shared architecture concepts for Wallet UI React Native, with kit a
 
 import { TabItem, Tabs } from '@astrojs/starlight/components';
 
-Wallet UI is a modular React Native SDK for mobile wallet interactions. Both package variants use the same Mobile Wallet Adapter flow, while the Solana client and transaction types differ.
+Wallet UI is a modular React Native SDK for mobile wallet interactions. Both package variants use Mobile Wallet Adapter on Android, while iOS currently exposes an unsupported wallet state so apps can build and render without crashing.
 
 ## Architecture overview
 
@@ -14,7 +14,8 @@ Both React Native packages provide:
 - `MobileWalletProvider` to configure wallet access at the app boundary
 - `useMobileWallet` as the main hook for connect, disconnect, signing, and account access
 - `useAuthorization` for lower-level authorization control
-- Mobile Wallet Adapter support so the app can connect to any compatible installed wallet
+- Android Mobile Wallet Adapter support so the app can connect to compatible installed wallets
+- iOS unsupported-state metadata so apps can render disabled wallet actions until iOS wallet connectivity is implemented
 
 ## Package-specific differences
 
@@ -41,11 +42,11 @@ Both React Native packages provide:
 
 ## Mobile Wallet Adapter
 
-Mobile Wallet Adapter is the shared protocol both packages implement. It defines the secure connection between your app and a wallet for:
+Mobile Wallet Adapter is the Android wallet transport both packages use today. It defines the secure connection between your app and a wallet for:
 
 - authorizing accounts
+- signing and sending transactions
 - signing messages
 - signing transactions
-- signing and sending transactions
 
-Because both packages target the same protocol, the end-user wallet flow is the same even when the app-facing client types differ.
+On iOS, Wallet UI does not currently provide a real wallet transport. The React Native packages expose `isSupported`, `platform`, and `capabilities` from `useMobileWallet()` so apps can render gracefully instead of failing during import or provider setup.

--- a/docs/src/content/docs/react-native/guides/expo.mdx
+++ b/docs/src/content/docs/react-native/guides/expo.mdx
@@ -55,7 +55,7 @@ Install the native dependencies required by Mobile Wallet Adapter:
 
 ## Build the app
 
-Create and run a development build:
+Create and run a development build. Android supports wallet connectivity through Mobile Wallet Adapter today. iOS can build and render the provider, but wallet connection and signing methods report an unsupported state until a real iOS transport is added.
 
 <PackageManagerTabs
     npm={`npx expo run:ios
@@ -65,6 +65,8 @@ pnpm dlx expo run:android`}
     bun={`bunx expo run:ios
 bunx expo run:android`}
 />
+
+On iOS, use `isSupported` from `useMobileWallet()` to disable wallet actions.
 
 ## Create app providers
 
@@ -136,7 +138,7 @@ Add a simple connection component to confirm the provider is working.
 		import { Button, Text, View } from 'react-native';
 
     	export default function IndexScreen() {
-    	    const { account, connect, disconnect } = useMobileWallet();
+    	    const { account, connect, disconnect, isSupported } = useMobileWallet();
 
     	    const handleConnect = useCallback(async () => {
     	        await connect();
@@ -154,7 +156,7 @@ Add a simple connection component to confirm the provider is working.
     	                    <Button title="Disconnect" onPress={handleDisconnect} />
     	                </>
     	            ) : (
-    	                <Button title="Connect Wallet" onPress={handleConnect} />
+    	                <Button disabled={!isSupported} title="Connect Wallet" onPress={handleConnect} />
     	            )}
     	        </View>
     	    );
@@ -168,7 +170,7 @@ Add a simple connection component to confirm the provider is working.
     	import { Button, Text, View } from 'react-native';
 
     	export default function IndexScreen() {
-    	    const { account, connect, disconnect } = useMobileWallet();
+    	    const { account, connect, disconnect, isSupported } = useMobileWallet();
 
     	    const handleConnect = useCallback(async () => {
     	        await connect();
@@ -186,7 +188,7 @@ Add a simple connection component to confirm the provider is working.
     	                    <Button title="Disconnect" onPress={handleDisconnect} />
     	                </>
     	            ) : (
-    	                <Button title="Connect Wallet" onPress={handleConnect} />
+    	                <Button disabled={!isSupported} title="Connect Wallet" onPress={handleConnect} />
     	            )}
     	        </View>
     	    );

--- a/docs/src/content/docs/react-native/hooks/use-mobile-wallet.mdx
+++ b/docs/src/content/docs/react-native/hooks/use-mobile-wallet.mdx
@@ -5,9 +5,11 @@ description: The primary hook for interacting with the mobile wallet across the 
 
 import { TabItem, Tabs } from '@astrojs/starlight/components';
 
-The `useMobileWallet` hook is the primary hook for interacting with the mobile wallet. Both variants support connect, disconnect, signing messages, and signing transactions, but the exposed client types and helper methods differ.
+The `useMobileWallet` hook is the primary hook for interacting with the mobile wallet. Both variants support connect, disconnect, signing messages, and signing transactions on Android, but the exposed client types and helper methods differ.
 
 The wallet lifecycle methods are largely shared. The main differences are the client object returned by the hook, the transaction helper surface, and the account types.
+
+On iOS, wallet operations are not implemented yet. The hook still returns a stable object, but wallet operation methods reject with `WalletUiUnsupportedPlatformError` and `isSupported` is `false`.
 
 <Tabs syncKey="rn-sdk">
 	<TabItem label="Kit">
@@ -20,11 +22,14 @@ The wallet lifecycle methods are largely shared. The main differences are the cl
     	| `accounts`               | `Account[] \| null`                                                                                | An array of all authorized accounts.                     |
     	| `account`                | `Account \| null`                                                                                  | The currently selected wallet account.                   |
     	| `chain`                  | `SolanaClusterId`                                                                                  | The current cluster identifier.                          |
+    	| `capabilities`           | `MobileWalletCapability[]`                                                                         | Wallet operations available on the current platform.     |
     	| `connect`                | `() => Promise<Account>`                                                                           | Connect to a wallet.                                     |
     	| `connectAnd`             | `(cb: (wallet: AuthorizeAPI) => Promise<Account \| void>) => Promise<Account \| void>`            | Connect and execute a callback.                          |
     	| `disconnect`             | `() => Promise<void>`                                                                              | Disconnect the current wallet.                           |
     	| `deauthorizeSession`     | `(wallet: DeauthorizeAPI) => Promise<void>`                                                        | Deauthorize the current session.                         |
     	| `getTransactionSigner`   | `(address: Address, minContextSlot: bigint) => TransactionSendingSigner`                           | Return a signer for Kit transaction pipelines.           |
+    	| `isSupported`            | `boolean`                                                                                          | `true` when wallet operations are available.             |
+    	| `platform`               | `android \| ios \| unsupported`                                                                    | The detected mobile wallet platform.                     |
     	| `sendTransaction`        | `(instructions: Instruction[]) => Promise<string>`                                                 | Create, sign, and send a transaction from instructions.  |
     	| `signAndSendTransaction` | `(transaction: Transaction \| Transaction[], minContextSlot: bigint) => Promise<SignatureBytes[]>` | Sign and send one or more Kit transactions.              |
     	| `signTransaction`        | `(transaction: Transaction \| Transaction[]) => Promise<Transaction \| Transaction[]>`             | Sign one or more Kit transactions without sending them.  |
@@ -55,7 +60,7 @@ The wallet lifecycle methods are largely shared. The main differences are the cl
     	import { Button, Text, View } from 'react-native';
 
     	function WalletConnector() {
-    	    const { account, connect, disconnect } = useMobileWallet();
+    	    const { account, connect, disconnect, isSupported } = useMobileWallet();
 
     	    const handleConnect = useCallback(async () => {
     	        await connect();
@@ -73,7 +78,7 @@ The wallet lifecycle methods are largely shared. The main differences are the cl
     	                    <Button title="Disconnect" onPress={handleDisconnect} />
     	                </>
     	            ) : (
-    	                <Button title="Connect Wallet" onPress={handleConnect} />
+    	                <Button disabled={!isSupported} title="Connect Wallet" onPress={handleConnect} />
     	            )}
     	        </View>
     	    );
@@ -89,11 +94,14 @@ The wallet lifecycle methods are largely shared. The main differences are the cl
     	| `connection`                 | `Connection`                                                                                                                                                                         | The Solana connection configured in `MobileWalletProvider`. |
     	| `identity`                   | `AppIdentity`                                                                                                                                                                        | The app identity configured in `MobileWalletProvider`.      |
     	| `accounts`                   | `Account[] \| null`                                                                                                                                                                  | An array of all authorized accounts.                        |
+    	| `capabilities`               | `MobileWalletCapability[]`                                                                                                                                                           | Wallet operations available on the current platform.        |
     	| `authorizeSession`           | `(wallet: AuthorizeAPI) => Promise<Account>`                                                                                                                                         | Authorize a new session.                                    |
     	| `authorizeSessionWithSignIn` | `(wallet: AuthorizeAPI, signInPayload: SignInPayload) => Promise<Account>`                                                                                                           | Authorize a new session with sign-in.                       |
     	| `deauthorizeSession`         | `(wallet: DeauthorizeAPI) => Promise<void>`                                                                                                                                          | Deauthorize the current session.                            |
     	| `deauthorizeSessions`        | `() => Promise<void>`                                                                                                                                                                | Deauthorize all sessions.                                   |
     	| `isLoading`                  | `boolean`                                                                                                                                                                            | Whether the authorization state is still loading.           |
+    	| `isSupported`                | `boolean`                                                                                                                                                                            | `true` when wallet operations are available.                |
+    	| `platform`                   | `android \| ios \| unsupported`                                                                                                                                                      | The detected mobile wallet platform.                        |
     	| `account`                    | `Account \| null`                                                                                                                                                                    | The currently selected wallet account.                      |
     	| `connect`                    | `() => Promise<Account>`                                                                                                                                                             | Connect to a wallet.                                        |
     	| `connectAnd`                 | `(cb: (wallet: AuthorizeAPI) => Promise<Account \| void>) => Promise<Account \| void>`                                                                                              | Connect and execute a callback.                             |
@@ -120,7 +128,7 @@ The wallet lifecycle methods are largely shared. The main differences are the cl
     	import { Button, Text, View } from 'react-native';
 
     	function WalletConnector() {
-    	    const { account, connect, disconnect, signAndSendTransaction } = useMobileWallet();
+    	    const { account, connect, disconnect, isSupported, signAndSendTransaction } = useMobileWallet();
 
     	    const handleConnect = useCallback(async () => {
     	        await connect();
@@ -153,7 +161,7 @@ The wallet lifecycle methods are largely shared. The main differences are the cl
     	                    <Button title="Send Dummy Transaction" onPress={handleSendTransaction} />
     	                </>
     	            ) : (
-    	                <Button title="Connect Wallet" onPress={handleConnect} />
+    	                <Button disabled={!isSupported} title="Connect Wallet" onPress={handleConnect} />
     	            )}
     	        </View>
     	    );

--- a/examples/expo-kit/features/account/account-feature-connect.tsx
+++ b/examples/expo-kit/features/account/account-feature-connect.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { useMobileWallet } from '@wallet-ui/react-native-kit';
 
 export function AccountFeatureConnect() {
-    const { account, connect } = useMobileWallet();
+    const { account, connect, isSupported } = useMobileWallet();
 
-    return <Button disabled={!!account} title="Connect" onPress={connect} />;
+    return <Button disabled={!!account || !isSupported} title="Connect" onPress={connect} />;
 }

--- a/examples/expo-kit/test/app.integration-test.tsx
+++ b/examples/expo-kit/test/app.integration-test.tsx
@@ -3,6 +3,7 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { MobileWalletProvider } from '@wallet-ui/react-native-kit';
 import React from 'react';
+import { Platform } from 'react-native';
 import { act, create } from 'react-test-renderer';
 import HomeScreen from '@/app/index';
 import { AppConfig } from '@/constants/app-config';
@@ -27,6 +28,7 @@ describe('expo-kit app integration', () => {
         jest.spyOn(console, 'error').mockImplementation(() => {});
         jest.spyOn(console, 'log').mockImplementation(() => {});
         mockTransact.mockReset();
+        Platform.OS = 'android';
     });
 
     afterEach(() => {
@@ -108,6 +110,22 @@ describe('expo-kit app integration', () => {
         expect(findButton(renderer, 'Connect')).toBeTruthy();
         expect(hasText(renderer, 'Connected to Primary')).toBe(false);
         expect(cache.clear).toHaveBeenCalledTimes(1);
+    });
+
+    it('renders a disabled wallet connection state on iOS', async () => {
+        expect.assertions(3);
+
+        Platform.OS = 'ios';
+        const cache = createMemoryCache();
+        const client = createMockClient();
+        const wallet = createMockWallet();
+        const renderer = await renderHomeScreen({ cache, client, wallet });
+
+        await waitForCondition(() => hasText(renderer, 'Version: 2.0.0 (123)'));
+
+        expect(findButton(renderer, 'Connect')).toBeTruthy();
+        expect(findButton(renderer, 'Connect').props.disabled).toBe(true);
+        expect(mockTransact).not.toHaveBeenCalled();
     });
 
     it('rehydrates a cached connection after remount without reauthorizing', async () => {

--- a/examples/expo-kit/test/mocks/react-native.js
+++ b/examples/expo-kit/test/mocks/react-native.js
@@ -1,7 +1,12 @@
 const React = require('react');
 
+const Platform = {
+    OS: 'android',
+};
+
 module.exports = {
     Button: ({ disabled, onPress, title }) => React.createElement('Button', { disabled, onPress, title }, title),
+    Platform,
     StyleSheet: {
         create: styles => styles,
     },

--- a/examples/expo-web3js/features/account/account-feature-connect.tsx
+++ b/examples/expo-web3js/features/account/account-feature-connect.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { useMobileWallet } from '@wallet-ui/react-native-web3js';
 
 export function AccountFeatureConnect() {
-    const { account, connect } = useMobileWallet();
+    const { account, connect, isSupported } = useMobileWallet();
 
-    return <Button disabled={!!account} title="Connect" onPress={connect} />;
+    return <Button disabled={!!account || !isSupported} title="Connect" onPress={connect} />;
 }

--- a/examples/expo-web3js/test/app.integration-test.tsx
+++ b/examples/expo-web3js/test/app.integration-test.tsx
@@ -3,6 +3,7 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { MobileWalletProvider } from '@wallet-ui/react-native-web3js';
 import React from 'react';
+import { Platform } from 'react-native';
 import { act, create } from 'react-test-renderer';
 import HomeScreen from '@/app/index';
 import { AppConfig } from '@/constants/app-config';
@@ -38,6 +39,7 @@ describe('expo-web3js app integration', () => {
         jest.spyOn(console, 'log').mockImplementation(() => {});
         mockConnectionConstructor.mockReset();
         mockTransact.mockReset();
+        Platform.OS = 'android';
     });
 
     afterEach(() => {
@@ -119,6 +121,22 @@ describe('expo-web3js app integration', () => {
         expect(findButton(renderer, 'Connect')).toBeTruthy();
         expect(hasText(renderer, 'Connected to Primary')).toBe(false);
         expect(cache.clear).toHaveBeenCalledTimes(1);
+    });
+
+    it('renders a disabled wallet connection state on iOS', async () => {
+        expect.assertions(3);
+
+        Platform.OS = 'ios';
+        const cache = createMemoryCache();
+        const connection = createMockConnection();
+        const wallet = createMockWallet();
+        const renderer = await renderHomeScreen({ cache, connection, wallet });
+
+        await waitForCondition(() => hasText(renderer, 'Version: 2.0.0 (123)'));
+
+        expect(findButton(renderer, 'Connect')).toBeTruthy();
+        expect(findButton(renderer, 'Connect').props.disabled).toBe(true);
+        expect(mockTransact).not.toHaveBeenCalled();
     });
 
     it('rehydrates a cached connection after remount without reauthorizing', async () => {

--- a/examples/expo-web3js/test/mocks/react-native.js
+++ b/examples/expo-web3js/test/mocks/react-native.js
@@ -1,7 +1,12 @@
 const React = require('react');
 
+const Platform = {
+    OS: 'android',
+};
+
 module.exports = {
     Button: ({ disabled, onPress, title }) => React.createElement('Button', { disabled, onPress, title }, title),
+    Platform,
     StyleSheet: {
         create: styles => styles,
     },

--- a/packages/build-scripts/getBaseConfig.ts
+++ b/packages/build-scripts/getBaseConfig.ts
@@ -1,3 +1,4 @@
+import { existsSync } from 'node:fs';
 import { env } from 'node:process';
 
 import browsersListToEsBuild from 'browserslist-to-esbuild';
@@ -10,6 +11,10 @@ type Platform =
     // React Native
     | 'native'
     | 'node';
+
+function getPackageEntries() {
+    return ['./src/index.ts', existsSync('./src/android.ts') ? './src/android.ts' : null].filter(Boolean) as string[];
+}
 
 const BROWSERSLIST_TARGETS = browsersListToEsBuild();
 
@@ -26,7 +31,7 @@ export function getBaseConfig(platform: Platform, formats: Format[], _options: O
                               __REACTNATIVE__: `${platform === 'native'}`,
                               __VERSION__: `"${env.npm_package_version}"`,
                           },
-                          entry: [`./src/index.ts`],
+                          entry: getPackageEntries(),
                           esbuildOptions(options, context) {
                               const { format } = context;
                               options.minify = format === 'iife' && !isDebugBuild;

--- a/packages/react-native-kit/package.json
+++ b/packages/react-native-kit/package.json
@@ -22,6 +22,26 @@
             },
             "react-native": "./dist/index.native.mjs",
             "types": "./dist/types/index.d.ts"
+        },
+        "./android": {
+            "edge-light": {
+                "import": "./dist/android.node.mjs",
+                "require": "./dist/android.node.cjs"
+            },
+            "workerd": {
+                "import": "./dist/android.node.mjs",
+                "require": "./dist/android.node.cjs"
+            },
+            "browser": {
+                "import": "./dist/android.browser.mjs",
+                "require": "./dist/android.browser.cjs"
+            },
+            "node": {
+                "import": "./dist/android.node.mjs",
+                "require": "./dist/android.node.cjs"
+            },
+            "react-native": "./dist/android.native.mjs",
+            "types": "./dist/types/android.d.ts"
         }
     },
     "browser": {

--- a/packages/react-native-kit/src/__tests__/index-test.ts
+++ b/packages/react-native-kit/src/__tests__/index-test.ts
@@ -16,12 +16,13 @@ jest.mock('@react-native-async-storage/async-storage', () => ({
 
 describe('index', () => {
     it('re-exports the local runtime surface from the barrel', () => {
-        expect.assertions(6);
+        expect.assertions(7);
 
         expect(reactNativeKit.MobileWalletProvider).toBe(MobileWalletProvider);
         expect(reactNativeKit.MobileWalletProviderContext).toBe(MobileWalletProviderContext);
         expect(reactNativeKit.convertSignInResult).toBe(convertSignInResult);
         expect(reactNativeKit.createAuthorizationStore).toBe(createAuthorizationStore);
+        expect('transact' in reactNativeKit).toBe(false);
         expect(reactNativeKit.useAuthorization).toBe(useAuthorization);
         expect(reactNativeKit.useMobileWallet).toBe(useMobileWallet);
     });

--- a/packages/react-native-kit/src/__tests__/use-mobile-wallet-test.tsx
+++ b/packages/react-native-kit/src/__tests__/use-mobile-wallet-test.tsx
@@ -20,6 +20,10 @@ const mockSignAndSendTransactionMessageWithSigners = jest.fn();
 const mockTransact = jest.fn();
 const mockUseAuthorization = jest.fn();
 
+const mockPlatform = {
+    OS: 'android',
+};
+
 jest.mock('@react-native-async-storage/async-storage', () => ({
     __esModule: true,
     default: {
@@ -39,6 +43,14 @@ jest.mock('react', () => {
         useMemo: (factory: () => unknown) => factory(),
     };
 });
+
+jest.mock(
+    'react-native',
+    () => ({
+        Platform: mockPlatform,
+    }),
+    { virtual: true },
+);
 
 jest.mock('@solana-mobile/mobile-wallet-adapter-protocol-kit', () => ({
     transact: (...args: unknown[]) => mockTransact(...args),
@@ -64,13 +76,41 @@ jest.mock('../use-authorization', () => ({
 
 describe('useMobileWallet', () => {
     it('connects through the transport and returns the selected account', async () => {
-        expect.assertions(3);
+        expect.assertions(6);
         const { mobileWallet } = useMobileWalletTestHarness();
         const account = await mobileWallet.connect();
 
         expect(mockTransact).toHaveBeenCalledTimes(1);
         expect(mockAuthorizeSession).toHaveBeenCalledWith(expect.objectContaining({ authorize: expect.any(Function) }));
         expect(account).toEqual(createExpectedAccount({ label: 'Primary' }));
+        expect(mobileWallet.capabilities).toEqual([
+            'connect',
+            'disconnect',
+            'signAndSendTransactions',
+            'signIn',
+            'signMessages',
+            'signTransactions',
+        ]);
+        expect(mobileWallet.isSupported).toBe(true);
+        expect(mobileWallet.platform).toBe('android');
+    });
+
+    it('returns unsupported metadata and rejects wallet operations on iOS', async () => {
+        expect.assertions(8);
+        const { mobileWallet } = useMobileWalletTestHarness({
+            platform: 'ios',
+        });
+
+        expect(mobileWallet.account).toBeUndefined();
+        expect(mobileWallet.accounts).toEqual([]);
+        expect(mobileWallet.capabilities).toEqual([]);
+        expect(mobileWallet.isSupported).toBe(false);
+        expect(mobileWallet.platform).toBe('ios');
+        await expect(mobileWallet.connect()).rejects.toThrow('Mobile wallet operations are not supported on iOS.');
+        await expect(mobileWallet.signMessages(Uint8Array.from([1, 2, 3]))).rejects.toThrow(
+            'Mobile wallet operations are not supported on iOS.',
+        );
+        expect(mockTransact).not.toHaveBeenCalled();
     });
 
     it('passes the transport wallet into connectAnd callbacks', async () => {
@@ -302,11 +342,14 @@ function createTransportWallet({
 
 function useMobileWalletTestHarness({
     contextOverrides,
+    platform = 'android',
     transportWallet = createTransportWallet(),
 }: {
     contextOverrides?: Record<string, unknown>;
+    platform?: string;
     transportWallet?: ReturnType<typeof createTransportWallet>;
 } = {}) {
+    mockPlatform.OS = platform;
     currentContext = createContextValue(contextOverrides);
     resetAsyncStorageMock(AsyncStorage as unknown as Parameters<typeof resetAsyncStorageMock>[0]);
     mockAppendTransactionMessageInstructions.mockImplementation((instructions, transactionMessage) => ({

--- a/packages/react-native-kit/src/android.ts
+++ b/packages/react-native-kit/src/android.ts
@@ -1,0 +1,1 @@
+export * from '@solana-mobile/mobile-wallet-adapter-protocol-kit';

--- a/packages/react-native-kit/src/errors.ts
+++ b/packages/react-native-kit/src/errors.ts
@@ -1,0 +1,19 @@
+export class WalletUiFeatureUnavailableError extends Error {
+    override name = 'WalletUiFeatureUnavailableError';
+}
+
+export class WalletUiUnsupportedPlatformError extends Error {
+    override name = 'WalletUiUnsupportedPlatformError';
+
+    constructor(platform: string) {
+        super(`Mobile wallet operations are not supported on ${getPlatformLabel(platform)}.`);
+    }
+}
+
+export class WalletUiWalletUnavailableError extends Error {
+    override name = 'WalletUiWalletUnavailableError';
+}
+
+function getPlatformLabel(platform: string) {
+    return platform === 'ios' ? 'iOS' : platform;
+}

--- a/packages/react-native-kit/src/index.ts
+++ b/packages/react-native-kit/src/index.ts
@@ -1,12 +1,14 @@
 export * from './authorization-store';
 export * from './cache';
 export * from './convert-sign-in-result';
+export * from './errors';
+export * from './mobile-wallet-platform';
 export * from './mobile-wallet-provider';
+export * from './mobile-wallet-transport';
 export * from './use-authorization';
 export * from './use-mobile-wallet';
 
 export type { AppIdentity, SignInPayload } from '@solana-mobile/mobile-wallet-adapter-protocol';
-export * from '@solana-mobile/mobile-wallet-adapter-protocol-kit';
 export * from '@wallet-ui/core';
 export { toUint8Array, fromUint8Array } from 'js-base64';
 export { createDefaultClient } from './create-default-client';

--- a/packages/react-native-kit/src/mobile-wallet-platform.ts
+++ b/packages/react-native-kit/src/mobile-wallet-platform.ts
@@ -1,0 +1,48 @@
+export type MobileWalletCapability =
+    | 'connect'
+    | 'disconnect'
+    | 'signAndSendTransactions'
+    | 'signIn'
+    | 'signMessages'
+    | 'signTransactions';
+
+export type MobileWalletPlatform = 'android' | 'ios' | 'unsupported';
+
+export const ANDROID_MOBILE_WALLET_CAPABILITIES = Object.freeze([
+    'connect',
+    'disconnect',
+    'signAndSendTransactions',
+    'signIn',
+    'signMessages',
+    'signTransactions',
+] as const satisfies readonly MobileWalletCapability[]);
+
+type ReactNativePlatformModule = Readonly<{
+    Platform?: Readonly<{
+        OS?: string;
+    }>;
+}>;
+
+export function getMobileWalletPlatform(): MobileWalletPlatform {
+    const os = getReactNativePlatformOS();
+
+    if (os === 'android') {
+        return 'android';
+    }
+
+    if (os === 'ios') {
+        return 'ios';
+    }
+
+    return 'unsupported';
+}
+
+function getReactNativePlatformOS() {
+    try {
+        // eslint-disable-next-line @typescript-eslint/no-require-imports -- React Native is an optional runtime dependency here.
+        const reactNative = require('react-native') as ReactNativePlatformModule;
+        return reactNative.Platform?.OS;
+    } catch {
+        return undefined;
+    }
+}

--- a/packages/react-native-kit/src/mobile-wallet-transport.ts
+++ b/packages/react-native-kit/src/mobile-wallet-transport.ts
@@ -1,0 +1,46 @@
+import { WalletUiUnsupportedPlatformError } from './errors';
+import {
+    ANDROID_MOBILE_WALLET_CAPABILITIES,
+    getMobileWalletPlatform,
+    type MobileWalletCapability,
+    type MobileWalletPlatform,
+} from './mobile-wallet-platform';
+
+type AndroidTransact = (typeof import('@solana-mobile/mobile-wallet-adapter-protocol-kit'))['transact'];
+type AndroidWallet = Parameters<Parameters<AndroidTransact>[0]>[0];
+
+export interface MobileWalletTransport {
+    capabilities: readonly MobileWalletCapability[];
+    isSupported: boolean;
+    platform: MobileWalletPlatform;
+    transact<T>(callback: (wallet: AndroidWallet) => Promise<T>): Promise<T>;
+}
+
+export function createMobileWalletTransport(): MobileWalletTransport {
+    const platform = getMobileWalletPlatform();
+
+    if (platform === 'android') {
+        return {
+            capabilities: ANDROID_MOBILE_WALLET_CAPABILITIES,
+            isSupported: true,
+            platform,
+            transact: async callback => await getAndroidTransact()(callback),
+        };
+    }
+
+    return {
+        capabilities: [],
+        isSupported: false,
+        platform,
+        transact: () => Promise.reject(new WalletUiUnsupportedPlatformError(platform)),
+    };
+}
+
+function getAndroidTransact(): AndroidTransact {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports -- Android MWA must stay lazily loaded.
+    const mobileWalletAdapter = require('@solana-mobile/mobile-wallet-adapter-protocol-kit') as {
+        transact: AndroidTransact;
+    };
+
+    return mobileWalletAdapter.transact;
+}

--- a/packages/react-native-kit/src/use-mobile-wallet.ts
+++ b/packages/react-native-kit/src/use-mobile-wallet.ts
@@ -12,17 +12,18 @@ import {
     TransactionSendingSigner,
 } from '@solana/kit';
 import { AuthorizeAPI, SignInPayload } from '@solana-mobile/mobile-wallet-adapter-protocol';
-import { transact } from '@solana-mobile/mobile-wallet-adapter-protocol-kit';
 import { useCallback, useContext, useMemo } from 'react';
 
 import { SignInOutput } from './convert-sign-in-result';
 import { MobileWalletProviderContext } from './mobile-wallet-provider';
+import { createMobileWalletTransport } from './mobile-wallet-transport';
 import { TransactionSignatures } from './types';
 import { Account, useAuthorization } from './use-authorization';
 
 const decoder = getBase58Decoder();
 export function useMobileWallet() {
     const ctx = useContext(MobileWalletProviderContext);
+    const transport = useMemo(() => createMobileWalletTransport(), []);
     const {
         authorizeSessionWithSignIn,
         authorizeSession,
@@ -33,21 +34,21 @@ export function useMobileWallet() {
     } = useAuthorization(ctx);
 
     const connect = useCallback(
-        async (): Promise<Account> => await transact(async wallet => await authorizeSession(wallet)),
-        [authorizeSession],
+        async (): Promise<Account> => await transport.transact(async wallet => await authorizeSession(wallet)),
+        [authorizeSession, transport],
     );
 
     const connectAnd = useCallback(
         async (cb: (wallet: AuthorizeAPI) => Promise<Account | void>): Promise<Account | void> => {
-            return await transact(async wallet => await cb(wallet));
+            return await transport.transact(async wallet => await cb(wallet));
         },
-        [],
+        [transport],
     );
 
     const signIn = useCallback(
         async (signInPayload: SignInPayload): Promise<SignInOutput> =>
-            await transact(async wallet => await authorizeSessionWithSignIn(wallet, signInPayload)),
-        [authorizeSessionWithSignIn],
+            await transport.transact(async wallet => await authorizeSessionWithSignIn(wallet, signInPayload)),
+        [authorizeSessionWithSignIn, transport],
     );
 
     const disconnect = useCallback(async (): Promise<void> => await deauthorizeSessions(), [deauthorizeSessions]);
@@ -57,7 +58,7 @@ export function useMobileWallet() {
             transaction: T,
             minContextSlot: bigint,
         ): Promise<TransactionSignatures<T>> =>
-            await transact(async wallet => {
+            await transport.transact(async wallet => {
                 await authorizeSession(wallet);
                 const isTransactionsArray = Array.isArray(transaction);
                 const signatures = await wallet.signAndSendTransactions({
@@ -69,12 +70,12 @@ export function useMobileWallet() {
                     ? (signatures as TransactionSignatures<T>)
                     : (signatures[0] as TransactionSignatures<T>);
             }),
-        [authorizeSession],
+        [authorizeSession, transport],
     );
 
     const signMessages = useCallback(
         async <K extends Uint8Array | Uint8Array[]>(message: K): Promise<K> =>
-            await transact(async wallet => {
+            await transport.transact(async wallet => {
                 const authResult = await authorizeSession(wallet);
                 const payloads: Uint8Array[] = Array.isArray(message) ? message : [message];
                 const signed = await wallet.signMessages({
@@ -83,12 +84,12 @@ export function useMobileWallet() {
                 });
                 return (Array.isArray(message) ? signed : signed[0]) as K;
             }),
-        [authorizeSession],
+        [authorizeSession, transport],
     );
 
     const signTransactions = useCallback(
         async <T extends Transaction | Transaction[]>(transaction: T): Promise<T> =>
-            await transact(async wallet => {
+            await transport.transact(async wallet => {
                 await authorizeSession(wallet);
                 const signedTxs = await wallet.signTransactions({
                     transactions: Array.isArray(transaction) ? transaction : [transaction],
@@ -96,7 +97,7 @@ export function useMobileWallet() {
                 return Array.isArray(transaction) ? signedTxs : signedTxs[0];
             }),
 
-        [authorizeSession],
+        [authorizeSession, transport],
     );
 
     const getTransactionSigner = useCallback(
@@ -178,13 +179,16 @@ export function useMobileWallet() {
     return useMemo(
         () => ({
             ...ctx,
-            account: selectedAccount,
-            accounts,
+            account: transport.isSupported ? selectedAccount : undefined,
+            accounts: transport.isSupported ? accounts : [],
+            capabilities: transport.capabilities,
             connect,
             connectAnd,
             deauthorizeSession,
             disconnect,
             getTransactionSigner,
+            isSupported: transport.isSupported,
+            platform: transport.platform,
             sendTransaction,
             sendTransactions,
             signAndSendTransaction,
@@ -213,6 +217,7 @@ export function useMobileWallet() {
             signMessages,
             signTransaction,
             signTransactions,
+            transport,
         ],
     );
 }

--- a/packages/react-native-kit/tsconfig.declarations.json
+++ b/packages/react-native-kit/tsconfig.declarations.json
@@ -7,5 +7,5 @@
         "rootDir": "./src"
     },
     "extends": "./tsconfig.json",
-    "include": ["src/index.ts", "src/types"]
+    "include": ["src/android.ts", "src/index.ts", "src/types"]
 }

--- a/packages/react-native-web3js/package.json
+++ b/packages/react-native-web3js/package.json
@@ -22,6 +22,26 @@
             },
             "react-native": "./dist/index.native.mjs",
             "types": "./dist/types/index.d.ts"
+        },
+        "./android": {
+            "edge-light": {
+                "import": "./dist/android.node.mjs",
+                "require": "./dist/android.node.cjs"
+            },
+            "workerd": {
+                "import": "./dist/android.node.mjs",
+                "require": "./dist/android.node.cjs"
+            },
+            "browser": {
+                "import": "./dist/android.browser.mjs",
+                "require": "./dist/android.browser.cjs"
+            },
+            "node": {
+                "import": "./dist/android.node.mjs",
+                "require": "./dist/android.node.cjs"
+            },
+            "react-native": "./dist/android.native.mjs",
+            "types": "./dist/types/android.d.ts"
         }
     },
     "browser": {

--- a/packages/react-native-web3js/src/__tests__/index-test.ts
+++ b/packages/react-native-web3js/src/__tests__/index-test.ts
@@ -16,12 +16,13 @@ jest.mock('@react-native-async-storage/async-storage', () => ({
 
 describe('index', () => {
     it('re-exports the local runtime surface from the barrel', () => {
-        expect.assertions(6);
+        expect.assertions(7);
 
         expect(reactNativeWeb3js.MobileWalletProvider).toBe(MobileWalletProvider);
         expect(reactNativeWeb3js.MobileWalletProviderContext).toBe(MobileWalletProviderContext);
         expect(reactNativeWeb3js.convertSignInResult).toBe(convertSignInResult);
         expect(reactNativeWeb3js.createAuthorizationStore).toBe(createAuthorizationStore);
+        expect('transact' in reactNativeWeb3js).toBe(false);
         expect(reactNativeWeb3js.useAuthorization).toBe(useAuthorization);
         expect(reactNativeWeb3js.useMobileWallet).toBe(useMobileWallet);
     });

--- a/packages/react-native-web3js/src/__tests__/use-mobile-wallet-test.tsx
+++ b/packages/react-native-web3js/src/__tests__/use-mobile-wallet-test.tsx
@@ -14,6 +14,10 @@ const mockDeauthorizeSessions = jest.fn();
 const mockTransact = jest.fn();
 const mockUseAuthorization = jest.fn();
 
+const mockPlatform = {
+    OS: 'android',
+};
+
 jest.mock('@react-native-async-storage/async-storage', () => ({
     __esModule: true,
     default: {
@@ -34,6 +38,14 @@ jest.mock('react', () => {
     };
 });
 
+jest.mock(
+    'react-native',
+    () => ({
+        Platform: mockPlatform,
+    }),
+    { virtual: true },
+);
+
 jest.mock('@solana-mobile/mobile-wallet-adapter-protocol-web3js', () => ({
     transact: (...args: unknown[]) => mockTransact(...args),
 }));
@@ -48,13 +60,41 @@ describe('useMobileWallet', () => {
     });
 
     it('connects through the transport and returns the selected account', async () => {
-        expect.assertions(3);
+        expect.assertions(6);
         const { mobileWallet } = useMobileWalletTestHarness();
         const account = await mobileWallet.connect();
 
         expect(mockTransact).toHaveBeenCalledTimes(1);
         expect(mockAuthorizeSession).toHaveBeenCalledWith(expect.objectContaining({ authorize: expect.any(Function) }));
         expect(account).toEqual(createExpectedAccount({ label: 'Primary' }));
+        expect(mobileWallet.capabilities).toEqual([
+            'connect',
+            'disconnect',
+            'signAndSendTransactions',
+            'signIn',
+            'signMessages',
+            'signTransactions',
+        ]);
+        expect(mobileWallet.isSupported).toBe(true);
+        expect(mobileWallet.platform).toBe('android');
+    });
+
+    it('returns unsupported metadata and rejects wallet operations on iOS', async () => {
+        expect.assertions(8);
+        const { mobileWallet } = useMobileWalletTestHarness({
+            platform: 'ios',
+        });
+
+        expect(mobileWallet.account).toBeUndefined();
+        expect(mobileWallet.accounts).toEqual([]);
+        expect(mobileWallet.capabilities).toEqual([]);
+        expect(mobileWallet.isSupported).toBe(false);
+        expect(mobileWallet.platform).toBe('ios');
+        await expect(mobileWallet.connect()).rejects.toThrow('Mobile wallet operations are not supported on iOS.');
+        await expect(mobileWallet.signMessages(Uint8Array.from([1, 2, 3]))).rejects.toThrow(
+            'Mobile wallet operations are not supported on iOS.',
+        );
+        expect(mockTransact).not.toHaveBeenCalled();
     });
 
     it('passes the transport wallet into connectAnd callbacks', async () => {
@@ -184,11 +224,14 @@ function createTransportWallet({
 
 function useMobileWalletTestHarness({
     contextOverrides,
+    platform = 'android',
     transportWallet = createTransportWallet(),
 }: {
     contextOverrides?: Record<string, unknown>;
+    platform?: string;
     transportWallet?: ReturnType<typeof createTransportWallet>;
 } = {}) {
+    mockPlatform.OS = platform;
     currentContext = createContextValue(contextOverrides);
     resetAsyncStorageMock(AsyncStorage as unknown as Parameters<typeof resetAsyncStorageMock>[0]);
     mockAuthorizeSession.mockResolvedValue(createExpectedAccount({ label: 'Primary' }));

--- a/packages/react-native-web3js/src/android.ts
+++ b/packages/react-native-web3js/src/android.ts
@@ -1,0 +1,1 @@
+export * from '@solana-mobile/mobile-wallet-adapter-protocol-web3js';

--- a/packages/react-native-web3js/src/errors.ts
+++ b/packages/react-native-web3js/src/errors.ts
@@ -1,0 +1,19 @@
+export class WalletUiFeatureUnavailableError extends Error {
+    override name = 'WalletUiFeatureUnavailableError';
+}
+
+export class WalletUiUnsupportedPlatformError extends Error {
+    override name = 'WalletUiUnsupportedPlatformError';
+
+    constructor(platform: string) {
+        super(`Mobile wallet operations are not supported on ${getPlatformLabel(platform)}.`);
+    }
+}
+
+export class WalletUiWalletUnavailableError extends Error {
+    override name = 'WalletUiWalletUnavailableError';
+}
+
+function getPlatformLabel(platform: string) {
+    return platform === 'ios' ? 'iOS' : platform;
+}

--- a/packages/react-native-web3js/src/index.ts
+++ b/packages/react-native-web3js/src/index.ts
@@ -1,12 +1,14 @@
 export * from './authorization-store';
 export * from './cache';
 export * from './convert-sign-in-result';
+export * from './errors';
+export * from './mobile-wallet-platform';
 export * from './mobile-wallet-provider';
+export * from './mobile-wallet-transport';
 export * from './use-authorization';
 export * from './use-mobile-wallet';
 
 export type { AppIdentity, SignInPayload } from '@solana-mobile/mobile-wallet-adapter-protocol';
-export * from '@solana-mobile/mobile-wallet-adapter-protocol-web3js';
 export * from '@wallet-ui/core';
 export { toUint8Array, fromUint8Array } from 'js-base64';
 export { convertSignInResult } from './convert-sign-in-result';

--- a/packages/react-native-web3js/src/mobile-wallet-platform.ts
+++ b/packages/react-native-web3js/src/mobile-wallet-platform.ts
@@ -1,0 +1,48 @@
+export type MobileWalletCapability =
+    | 'connect'
+    | 'disconnect'
+    | 'signAndSendTransactions'
+    | 'signIn'
+    | 'signMessages'
+    | 'signTransactions';
+
+export type MobileWalletPlatform = 'android' | 'ios' | 'unsupported';
+
+export const ANDROID_MOBILE_WALLET_CAPABILITIES = Object.freeze([
+    'connect',
+    'disconnect',
+    'signAndSendTransactions',
+    'signIn',
+    'signMessages',
+    'signTransactions',
+] as const satisfies readonly MobileWalletCapability[]);
+
+type ReactNativePlatformModule = Readonly<{
+    Platform?: Readonly<{
+        OS?: string;
+    }>;
+}>;
+
+export function getMobileWalletPlatform(): MobileWalletPlatform {
+    const os = getReactNativePlatformOS();
+
+    if (os === 'android') {
+        return 'android';
+    }
+
+    if (os === 'ios') {
+        return 'ios';
+    }
+
+    return 'unsupported';
+}
+
+function getReactNativePlatformOS() {
+    try {
+        // eslint-disable-next-line @typescript-eslint/no-require-imports -- React Native is an optional runtime dependency here.
+        const reactNative = require('react-native') as ReactNativePlatformModule;
+        return reactNative.Platform?.OS;
+    } catch {
+        return undefined;
+    }
+}

--- a/packages/react-native-web3js/src/mobile-wallet-transport.ts
+++ b/packages/react-native-web3js/src/mobile-wallet-transport.ts
@@ -1,0 +1,46 @@
+import { WalletUiUnsupportedPlatformError } from './errors';
+import {
+    ANDROID_MOBILE_WALLET_CAPABILITIES,
+    getMobileWalletPlatform,
+    type MobileWalletCapability,
+    type MobileWalletPlatform,
+} from './mobile-wallet-platform';
+
+type AndroidTransact = (typeof import('@solana-mobile/mobile-wallet-adapter-protocol-web3js'))['transact'];
+type AndroidWallet = Parameters<Parameters<AndroidTransact>[0]>[0];
+
+export interface MobileWalletTransport {
+    capabilities: readonly MobileWalletCapability[];
+    isSupported: boolean;
+    platform: MobileWalletPlatform;
+    transact<T>(callback: (wallet: AndroidWallet) => Promise<T>): Promise<T>;
+}
+
+export function createMobileWalletTransport(): MobileWalletTransport {
+    const platform = getMobileWalletPlatform();
+
+    if (platform === 'android') {
+        return {
+            capabilities: ANDROID_MOBILE_WALLET_CAPABILITIES,
+            isSupported: true,
+            platform,
+            transact: async callback => await getAndroidTransact()(callback),
+        };
+    }
+
+    return {
+        capabilities: [],
+        isSupported: false,
+        platform,
+        transact: () => Promise.reject(new WalletUiUnsupportedPlatformError(platform)),
+    };
+}
+
+function getAndroidTransact(): AndroidTransact {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports -- Android MWA must stay lazily loaded.
+    const mobileWalletAdapter = require('@solana-mobile/mobile-wallet-adapter-protocol-web3js') as {
+        transact: AndroidTransact;
+    };
+
+    return mobileWalletAdapter.transact;
+}

--- a/packages/react-native-web3js/src/use-mobile-wallet.ts
+++ b/packages/react-native-web3js/src/use-mobile-wallet.ts
@@ -1,15 +1,16 @@
 import { Transaction, VersionedTransaction } from '@solana/web3.js';
 import { AuthorizeAPI, SignInPayload } from '@solana-mobile/mobile-wallet-adapter-protocol';
-import { transact } from '@solana-mobile/mobile-wallet-adapter-protocol-web3js';
 import { useCallback, useContext, useMemo } from 'react';
 
 import { SignInOutput } from './convert-sign-in-result';
 import { MobileWalletProviderContext } from './mobile-wallet-provider';
+import { createMobileWalletTransport } from './mobile-wallet-transport';
 import { TransactionSignatures } from './types';
 import { Account, useAuthorization } from './use-authorization';
 
 export function useMobileWallet() {
     const ctx = useContext(MobileWalletProviderContext);
+    const transport = useMemo(() => createMobileWalletTransport(), []);
     const {
         authorizeSessionWithSignIn,
         authorizeSession,
@@ -20,21 +21,21 @@ export function useMobileWallet() {
     } = useAuthorization(ctx);
 
     const connect = useCallback(
-        async (): Promise<Account> => await transact(async wallet => await authorizeSession(wallet)),
-        [authorizeSession],
+        async (): Promise<Account> => await transport.transact(async wallet => await authorizeSession(wallet)),
+        [authorizeSession, transport],
     );
 
     const connectAnd = useCallback(
         async (cb: (wallet: AuthorizeAPI) => Promise<Account | void>): Promise<Account | void> => {
-            return await transact(async wallet => await cb(wallet));
+            return await transport.transact(async wallet => await cb(wallet));
         },
-        [],
+        [transport],
     );
 
     const signIn = useCallback(
         async (signInPayload: SignInPayload): Promise<SignInOutput> =>
-            await transact(async wallet => await authorizeSessionWithSignIn(wallet, signInPayload)),
-        [authorizeSessionWithSignIn],
+            await transport.transact(async wallet => await authorizeSessionWithSignIn(wallet, signInPayload)),
+        [authorizeSessionWithSignIn, transport],
     );
 
     const disconnect = useCallback(async (): Promise<void> => await deauthorizeSessions(), [deauthorizeSessions]);
@@ -44,7 +45,7 @@ export function useMobileWallet() {
             transaction: K,
             minContextSlot: number,
         ): Promise<TransactionSignatures<K>> =>
-            await transact(async wallet => {
+            await transport.transact(async wallet => {
                 await authorizeSession(wallet);
 
                 const isTransactionsArray = Array.isArray(transaction);
@@ -58,12 +59,12 @@ export function useMobileWallet() {
                     ? (signatures as TransactionSignatures<K>)
                     : (signatures[0] as TransactionSignatures<K>);
             }),
-        [authorizeSession],
+        [authorizeSession, transport],
     );
 
     const signMessages = useCallback(
         async <K extends Uint8Array | Uint8Array[]>(message: K): Promise<K> =>
-            await transact(async wallet => {
+            await transport.transact(async wallet => {
                 const authResult = await authorizeSession(wallet);
                 const payloads: Uint8Array[] = Array.isArray(message) ? message : [message];
                 const signed = await wallet.signMessages({
@@ -72,12 +73,12 @@ export function useMobileWallet() {
                 });
                 return (Array.isArray(message) ? signed : signed[0]) as K;
             }),
-        [authorizeSession],
+        [authorizeSession, transport],
     );
 
     const signTransactions = useCallback(
         async <T extends Transaction | VersionedTransaction, K extends T | T[]>(transaction: K): Promise<K> =>
-            await transact(async wallet => {
+            await transport.transact(async wallet => {
                 await authorizeSession(wallet);
                 const signedTxs = await wallet.signTransactions({
                     transactions: Array.isArray(transaction) ? transaction : [transaction],
@@ -85,7 +86,7 @@ export function useMobileWallet() {
                 return Array.isArray(transaction) ? signedTxs : signedTxs[0];
             }),
 
-        [authorizeSession],
+        [authorizeSession, transport],
     );
 
     /** @deprecated Use signAndSendTransactions instead. */
@@ -121,12 +122,15 @@ export function useMobileWallet() {
     return useMemo(
         () => ({
             ...ctx,
-            account: selectedAccount,
-            accounts,
+            account: transport.isSupported ? selectedAccount : undefined,
+            accounts: transport.isSupported ? accounts : [],
+            capabilities: transport.capabilities,
             connect,
             connectAnd,
             deauthorizeSession,
             disconnect,
+            isSupported: transport.isSupported,
+            platform: transport.platform,
             signAndSendTransaction,
             signAndSendTransactions,
             signIn,
@@ -150,6 +154,7 @@ export function useMobileWallet() {
             signMessages,
             signTransaction,
             signTransactions,
+            transport,
         ],
     );
 }

--- a/packages/react-native-web3js/tsconfig.declarations.json
+++ b/packages/react-native-web3js/tsconfig.declarations.json
@@ -7,5 +7,5 @@
         "rootDir": "./src"
     },
     "extends": "./tsconfig.json",
-    "include": ["src/index.ts", "src/types"]
+    "include": ["src/android.ts", "src/index.ts", "src/types"]
 }


### PR DESCRIPTION
Add platform-aware mobile wallet transports for the React Native Kit and Web3.js packages so Android continues to use Mobile Wallet Adapter while unsupported platforms return stable metadata and rejected wallet operations.

Export the Android adapter protocol from a dedicated subpath, update the React Native examples to disable wallet connects when unsupported, and document the current Android-only transport behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Android Mobile Wallet Adapter accessible via `./android` subpath
  * Added platform detection to check wallet support status
  * iOS renders safely with unsupported wallet state, preventing app crashes

* **Documentation**
  * Clarified platform-specific wallet support (Android vs iOS)
  * Added code examples showing how to disable wallet features when unavailable

* **Tests**
  * Added platform-specific integration tests for Android and iOS scenarios

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wallet-ui/wallet-ui/pull/515)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->