### PR TITLE
fix(react-native): validate MWA identity URIs

### DIFF
--- a/.changeset/validate-mwa-identity-uri.md
+++ b/.changeset/validate-mwa-identity-uri.md
@@ -1,0 +1,6 @@
+---
+'@wallet-ui/react-native-kit': patch
+'@wallet-ui/react-native-web3js': patch
+---
+
+Validate Mobile Wallet Adapter identity URI schemes before launching React Native wallet authorization.

--- a/packages/react-native-kit/src/__tests__/use-authorization-test.tsx
+++ b/packages/react-native-kit/src/__tests__/use-authorization-test.tsx
@@ -1,5 +1,6 @@
 import {
     AppIdentity,
+    AuthorizeAPI,
     Chain,
     SignInPayload,
     SolanaMobileWalletAdapterProtocolError,
@@ -205,6 +206,23 @@ describe('useAuthorization', () => {
 
         expect(persist).toHaveBeenCalledWith(null);
     });
+
+    it('rejects invalid identity URI schemes before authorizing', async () => {
+        expect.assertions(2);
+        const wallet = createWallet();
+        const { authorization } = useAuthorizationTestHarness({
+            identity: {
+                name: 'My App',
+                uri: 'my_app://my-app',
+            },
+        });
+
+        await expect(authorization.authorizeSession(wallet as AuthorizeAPI)).rejects.toThrow(
+            'Invalid Mobile Wallet Adapter identity.uri',
+        );
+
+        expect(wallet.authorize).not.toHaveBeenCalled();
+    });
 });
 
 function createWallet({
@@ -224,7 +242,7 @@ function lastPersistedAuthorization(persist: jest.Mock): WalletAuthorization {
     return persist.mock.calls.at(-1)?.[0] as WalletAuthorization;
 }
 
-function useAuthorizationTestHarness() {
+function useAuthorizationTestHarness({ identity = IDENTITY }: { identity?: AppIdentity } = {}) {
     const persist = jest.fn().mockResolvedValue(undefined);
 
     mockUseAuthorizationStore.mockReturnValue({
@@ -235,7 +253,7 @@ function useAuthorizationTestHarness() {
     });
 
     return {
-        authorization: useAuthorization({ chain: CHAIN, identity: IDENTITY, store: {} as never }),
+        authorization: useAuthorization({ chain: CHAIN, identity, store: {} as never }),
         persist,
     };
 }

--- a/packages/react-native-kit/src/__tests__/use-mobile-wallet-test.tsx
+++ b/packages/react-native-kit/src/__tests__/use-mobile-wallet-test.tsx
@@ -85,6 +85,42 @@ describe('useMobileWallet', () => {
         expect(result).toBe('connected-via-callback');
     });
 
+    it('rejects invalid identity URI schemes before launching the wallet transport', async () => {
+        expect.assertions(2);
+        const { mobileWallet } = useMobileWalletTestHarness({
+            contextOverrides: {
+                identity: {
+                    name: 'My App',
+                    uri: 'my_app://my-app',
+                },
+            },
+        });
+
+        await expect(mobileWallet.connect()).rejects.toThrow('Invalid Mobile Wallet Adapter identity.uri');
+
+        expect(mockTransact).not.toHaveBeenCalled();
+    });
+
+    it('signs in through the transport wallet', async () => {
+        expect.assertions(3);
+        const signInPayload = {
+            domain: 'wallet-ui.dev',
+            statement: 'Sign in to Wallet UI',
+        };
+        const transportWallet = createTransportWallet();
+        const { mobileWallet } = useMobileWalletTestHarness({ transportWallet });
+
+        const result = await mobileWallet.signIn(signInPayload);
+
+        expect(mockTransact).toHaveBeenCalledTimes(1);
+        expect(mockAuthorizeSessionWithSignIn).toHaveBeenCalledWith(transportWallet, signInPayload);
+        expect(result).toEqual({
+            account: createExpectedAccount({ label: 'Primary' }),
+            signature: Uint8Array.from([1, 2, 3]),
+            signedMessage: Uint8Array.from([4, 5, 6]),
+        });
+    });
+
     it('signs messages with the authorized address', async () => {
         expect.assertions(3);
         const signedMessage = Uint8Array.from([9, 9, 9]);

--- a/packages/react-native-kit/src/assert-valid-identity-uri.ts
+++ b/packages/react-native-kit/src/assert-valid-identity-uri.ts
@@ -1,0 +1,14 @@
+import { AppIdentity } from '@solana-mobile/mobile-wallet-adapter-protocol';
+
+const VALID_URI_SCHEME = /^[A-Za-z][A-Za-z0-9+.-]*:/;
+
+export function assertValidIdentityUri(identity: AppIdentity): void {
+    const { uri } = identity;
+    if (uri == null || VALID_URI_SCHEME.test(uri)) {
+        return;
+    }
+
+    throw new Error(
+        'Invalid Mobile Wallet Adapter identity.uri: URI schemes must start with a letter and can only contain letters, numbers, plus signs, periods, and hyphens. Use a valid URI such as https://example.com or my-app://app.',
+    );
+}

--- a/packages/react-native-kit/src/use-authorization.ts
+++ b/packages/react-native-kit/src/use-authorization.ts
@@ -14,6 +14,7 @@ import {
 import { WalletIcon } from '@wallet-standard/core';
 import { useCallback, useMemo } from 'react';
 
+import { assertValidIdentityUri } from './assert-valid-identity-uri';
 import { AuthorizationStore } from './authorization-store';
 import { Cache } from './cache';
 import { convertSignInResult, SignInOutput } from './convert-sign-in-result';
@@ -55,6 +56,7 @@ export function useAuthorization({ chain, identity, store }: WalletAuthorization
 
     const authorizeSession = useCallback(
         async (wallet: AuthorizeAPI) => {
+            assertValidIdentityUri(identity);
             try {
                 const authorizationResult = await wallet.authorize({
                     auth_token: authToken,
@@ -81,6 +83,7 @@ export function useAuthorization({ chain, identity, store }: WalletAuthorization
 
     const authorizeSessionWithSignIn = useCallback(
         async (wallet: AuthorizeAPI, signInPayload: SignInPayload): Promise<SignInOutput> => {
+            assertValidIdentityUri(identity);
             try {
                 const result = await wallet.authorize({
                     auth_token: authToken,

--- a/packages/react-native-kit/src/use-mobile-wallet.ts
+++ b/packages/react-native-kit/src/use-mobile-wallet.ts
@@ -15,6 +15,7 @@ import { AuthorizeAPI, SignInPayload } from '@solana-mobile/mobile-wallet-adapte
 import { transact } from '@solana-mobile/mobile-wallet-adapter-protocol-kit';
 import { useCallback, useContext, useMemo } from 'react';
 
+import { assertValidIdentityUri } from './assert-valid-identity-uri';
 import { SignInOutput } from './convert-sign-in-result';
 import { MobileWalletProviderContext } from './mobile-wallet-provider';
 import { TransactionSignatures } from './types';
@@ -32,22 +33,25 @@ export function useMobileWallet() {
         deauthorizeSession,
     } = useAuthorization(ctx);
 
-    const connect = useCallback(
-        async (): Promise<Account> => await transact(async wallet => await authorizeSession(wallet)),
-        [authorizeSession],
-    );
+    const connect = useCallback(async (): Promise<Account> => {
+        assertValidIdentityUri(ctx.identity);
+        return await transact(async wallet => await authorizeSession(wallet));
+    }, [authorizeSession, ctx.identity]);
 
     const connectAnd = useCallback(
         async (cb: (wallet: AuthorizeAPI) => Promise<Account | void>): Promise<Account | void> => {
+            assertValidIdentityUri(ctx.identity);
             return await transact(async wallet => await cb(wallet));
         },
-        [],
+        [ctx.identity],
     );
 
     const signIn = useCallback(
-        async (signInPayload: SignInPayload): Promise<SignInOutput> =>
-            await transact(async wallet => await authorizeSessionWithSignIn(wallet, signInPayload)),
-        [authorizeSessionWithSignIn],
+        async (signInPayload: SignInPayload): Promise<SignInOutput> => {
+            assertValidIdentityUri(ctx.identity);
+            return await transact(async wallet => await authorizeSessionWithSignIn(wallet, signInPayload));
+        },
+        [authorizeSessionWithSignIn, ctx.identity],
     );
 
     const disconnect = useCallback(async (): Promise<void> => await deauthorizeSessions(), [deauthorizeSessions]);
@@ -56,8 +60,9 @@ export function useMobileWallet() {
         async <T extends Transaction | Transaction[]>(
             transaction: T,
             minContextSlot: bigint,
-        ): Promise<TransactionSignatures<T>> =>
-            await transact(async wallet => {
+        ): Promise<TransactionSignatures<T>> => {
+            assertValidIdentityUri(ctx.identity);
+            return await transact(async wallet => {
                 await authorizeSession(wallet);
                 const isTransactionsArray = Array.isArray(transaction);
                 const signatures = await wallet.signAndSendTransactions({
@@ -68,13 +73,15 @@ export function useMobileWallet() {
                 return isTransactionsArray
                     ? (signatures as TransactionSignatures<T>)
                     : (signatures[0] as TransactionSignatures<T>);
-            }),
-        [authorizeSession],
+            });
+        },
+        [authorizeSession, ctx.identity],
     );
 
     const signMessages = useCallback(
-        async <K extends Uint8Array | Uint8Array[]>(message: K): Promise<K> =>
-            await transact(async wallet => {
+        async <K extends Uint8Array | Uint8Array[]>(message: K): Promise<K> => {
+            assertValidIdentityUri(ctx.identity);
+            return await transact(async wallet => {
                 const authResult = await authorizeSession(wallet);
                 const payloads: Uint8Array[] = Array.isArray(message) ? message : [message];
                 const signed = await wallet.signMessages({
@@ -82,21 +89,24 @@ export function useMobileWallet() {
                     payloads,
                 });
                 return (Array.isArray(message) ? signed : signed[0]) as K;
-            }),
-        [authorizeSession],
+            });
+        },
+        [authorizeSession, ctx.identity],
     );
 
     const signTransactions = useCallback(
-        async <T extends Transaction | Transaction[]>(transaction: T): Promise<T> =>
-            await transact(async wallet => {
+        async <T extends Transaction | Transaction[]>(transaction: T): Promise<T> => {
+            assertValidIdentityUri(ctx.identity);
+            return await transact(async wallet => {
                 await authorizeSession(wallet);
                 const signedTxs = await wallet.signTransactions({
                     transactions: Array.isArray(transaction) ? transaction : [transaction],
                 });
                 return Array.isArray(transaction) ? signedTxs : signedTxs[0];
-            }),
+            });
+        },
 
-        [authorizeSession],
+        [authorizeSession, ctx.identity],
     );
 
     const getTransactionSigner = useCallback(

--- a/packages/react-native-web3js/src/__tests__/use-authorization-test.tsx
+++ b/packages/react-native-web3js/src/__tests__/use-authorization-test.tsx
@@ -1,5 +1,6 @@
 import {
     AppIdentity,
+    AuthorizeAPI,
     Chain,
     SignInPayload,
     SolanaMobileWalletAdapterProtocolError,
@@ -210,6 +211,23 @@ describe('useAuthorization', () => {
 
         expect(persist).toHaveBeenCalledWith(null);
     });
+
+    it('rejects invalid identity URI schemes before authorizing', async () => {
+        expect.assertions(2);
+        const wallet = createWallet();
+        const { authorization } = useAuthorizationTestHarness({
+            identity: {
+                name: 'My App',
+                uri: 'my_app://my-app',
+            },
+        });
+
+        await expect(authorization.authorizeSession(wallet as AuthorizeAPI)).rejects.toThrow(
+            'Invalid Mobile Wallet Adapter identity.uri',
+        );
+
+        expect(wallet.authorize).not.toHaveBeenCalled();
+    });
 });
 
 function createWallet({
@@ -229,7 +247,7 @@ function lastPersistedAuthorization(persist: jest.Mock): WalletAuthorization {
     return persist.mock.calls.at(-1)?.[0] as WalletAuthorization;
 }
 
-function useAuthorizationTestHarness() {
+function useAuthorizationTestHarness({ identity = IDENTITY }: { identity?: AppIdentity } = {}) {
     const persist = jest.fn().mockResolvedValue(undefined);
 
     mockUseAuthorizationStore.mockReturnValue({
@@ -240,7 +258,7 @@ function useAuthorizationTestHarness() {
     });
 
     return {
-        authorization: useAuthorization({ chain: CHAIN, identity: IDENTITY, store: {} as never }),
+        authorization: useAuthorization({ chain: CHAIN, identity, store: {} as never }),
         persist,
     };
 }

--- a/packages/react-native-web3js/src/__tests__/use-mobile-wallet-test.tsx
+++ b/packages/react-native-web3js/src/__tests__/use-mobile-wallet-test.tsx
@@ -69,6 +69,42 @@ describe('useMobileWallet', () => {
         expect(result).toBe('connected-via-callback');
     });
 
+    it('rejects invalid identity URI schemes before launching the wallet transport', async () => {
+        expect.assertions(2);
+        const { mobileWallet } = useMobileWalletTestHarness({
+            contextOverrides: {
+                identity: {
+                    name: 'My App',
+                    uri: 'my_app://my-app',
+                },
+            },
+        });
+
+        await expect(mobileWallet.connect()).rejects.toThrow('Invalid Mobile Wallet Adapter identity.uri');
+
+        expect(mockTransact).not.toHaveBeenCalled();
+    });
+
+    it('signs in through the transport wallet', async () => {
+        expect.assertions(3);
+        const signInPayload = {
+            domain: 'wallet-ui.dev',
+            statement: 'Sign in to Wallet UI',
+        };
+        const transportWallet = createTransportWallet();
+        const { mobileWallet } = useMobileWalletTestHarness({ transportWallet });
+
+        const result = await mobileWallet.signIn(signInPayload);
+
+        expect(mockTransact).toHaveBeenCalledTimes(1);
+        expect(mockAuthorizeSessionWithSignIn).toHaveBeenCalledWith(transportWallet, signInPayload);
+        expect(result).toEqual({
+            account: createExpectedAccount({ label: 'Primary' }),
+            signature: Uint8Array.from([1, 2, 3]),
+            signedMessage: Uint8Array.from([4, 5, 6]),
+        });
+    });
+
     it('signs messages with the authorized address', async () => {
         expect.assertions(3);
         const signedMessage = Uint8Array.from([9, 9, 9]);

--- a/packages/react-native-web3js/src/assert-valid-identity-uri.ts
+++ b/packages/react-native-web3js/src/assert-valid-identity-uri.ts
@@ -1,0 +1,14 @@
+import { AppIdentity } from '@solana-mobile/mobile-wallet-adapter-protocol';
+
+const VALID_URI_SCHEME = /^[A-Za-z][A-Za-z0-9+.-]*:/;
+
+export function assertValidIdentityUri(identity: AppIdentity): void {
+    const { uri } = identity;
+    if (uri == null || VALID_URI_SCHEME.test(uri)) {
+        return;
+    }
+
+    throw new Error(
+        'Invalid Mobile Wallet Adapter identity.uri: URI schemes must start with a letter and can only contain letters, numbers, plus signs, periods, and hyphens. Use a valid URI such as https://example.com or my-app://app.',
+    );
+}

--- a/packages/react-native-web3js/src/use-authorization.ts
+++ b/packages/react-native-web3js/src/use-authorization.ts
@@ -14,6 +14,7 @@ import {
 import { WalletIcon } from '@wallet-standard/core';
 import { useCallback, useMemo } from 'react';
 
+import { assertValidIdentityUri } from './assert-valid-identity-uri';
 import { AuthorizationStore } from './authorization-store';
 import { Cache } from './cache';
 import { convertSignInResult, SignInOutput } from './convert-sign-in-result';
@@ -59,6 +60,7 @@ export function useAuthorization({ chain, identity, store }: WalletAuthorization
 
     const authorizeSession = useCallback(
         async (wallet: AuthorizeAPI) => {
+            assertValidIdentityUri(identity);
             try {
                 const authorizationResult = await wallet.authorize({
                     auth_token: authToken,
@@ -85,6 +87,7 @@ export function useAuthorization({ chain, identity, store }: WalletAuthorization
 
     const authorizeSessionWithSignIn = useCallback(
         async (wallet: AuthorizeAPI, signInPayload: SignInPayload): Promise<SignInOutput> => {
+            assertValidIdentityUri(identity);
             try {
                 const result = await wallet.authorize({
                     auth_token: authToken,

--- a/packages/react-native-web3js/src/use-mobile-wallet.ts
+++ b/packages/react-native-web3js/src/use-mobile-wallet.ts
@@ -3,6 +3,7 @@ import { AuthorizeAPI, SignInPayload } from '@solana-mobile/mobile-wallet-adapte
 import { transact } from '@solana-mobile/mobile-wallet-adapter-protocol-web3js';
 import { useCallback, useContext, useMemo } from 'react';
 
+import { assertValidIdentityUri } from './assert-valid-identity-uri';
 import { SignInOutput } from './convert-sign-in-result';
 import { MobileWalletProviderContext } from './mobile-wallet-provider';
 import { TransactionSignatures } from './types';
@@ -19,22 +20,25 @@ export function useMobileWallet() {
         deauthorizeSession,
     } = useAuthorization(ctx);
 
-    const connect = useCallback(
-        async (): Promise<Account> => await transact(async wallet => await authorizeSession(wallet)),
-        [authorizeSession],
-    );
+    const connect = useCallback(async (): Promise<Account> => {
+        assertValidIdentityUri(ctx.identity);
+        return await transact(async wallet => await authorizeSession(wallet));
+    }, [authorizeSession, ctx.identity]);
 
     const connectAnd = useCallback(
         async (cb: (wallet: AuthorizeAPI) => Promise<Account | void>): Promise<Account | void> => {
+            assertValidIdentityUri(ctx.identity);
             return await transact(async wallet => await cb(wallet));
         },
-        [],
+        [ctx.identity],
     );
 
     const signIn = useCallback(
-        async (signInPayload: SignInPayload): Promise<SignInOutput> =>
-            await transact(async wallet => await authorizeSessionWithSignIn(wallet, signInPayload)),
-        [authorizeSessionWithSignIn],
+        async (signInPayload: SignInPayload): Promise<SignInOutput> => {
+            assertValidIdentityUri(ctx.identity);
+            return await transact(async wallet => await authorizeSessionWithSignIn(wallet, signInPayload));
+        },
+        [authorizeSessionWithSignIn, ctx.identity],
     );
 
     const disconnect = useCallback(async (): Promise<void> => await deauthorizeSessions(), [deauthorizeSessions]);
@@ -43,8 +47,9 @@ export function useMobileWallet() {
         async <T extends Transaction | VersionedTransaction, K extends T | T[]>(
             transaction: K,
             minContextSlot: number,
-        ): Promise<TransactionSignatures<K>> =>
-            await transact(async wallet => {
+        ): Promise<TransactionSignatures<K>> => {
+            assertValidIdentityUri(ctx.identity);
+            return await transact(async wallet => {
                 await authorizeSession(wallet);
 
                 const isTransactionsArray = Array.isArray(transaction);
@@ -57,13 +62,15 @@ export function useMobileWallet() {
                 return isTransactionsArray
                     ? (signatures as TransactionSignatures<K>)
                     : (signatures[0] as TransactionSignatures<K>);
-            }),
-        [authorizeSession],
+            });
+        },
+        [authorizeSession, ctx.identity],
     );
 
     const signMessages = useCallback(
-        async <K extends Uint8Array | Uint8Array[]>(message: K): Promise<K> =>
-            await transact(async wallet => {
+        async <K extends Uint8Array | Uint8Array[]>(message: K): Promise<K> => {
+            assertValidIdentityUri(ctx.identity);
+            return await transact(async wallet => {
                 const authResult = await authorizeSession(wallet);
                 const payloads: Uint8Array[] = Array.isArray(message) ? message : [message];
                 const signed = await wallet.signMessages({
@@ -71,21 +78,24 @@ export function useMobileWallet() {
                     payloads,
                 });
                 return (Array.isArray(message) ? signed : signed[0]) as K;
-            }),
-        [authorizeSession],
+            });
+        },
+        [authorizeSession, ctx.identity],
     );
 
     const signTransactions = useCallback(
-        async <T extends Transaction | VersionedTransaction, K extends T | T[]>(transaction: K): Promise<K> =>
-            await transact(async wallet => {
+        async <T extends Transaction | VersionedTransaction, K extends T | T[]>(transaction: K): Promise<K> => {
+            assertValidIdentityUri(ctx.identity);
+            return await transact(async wallet => {
                 await authorizeSession(wallet);
                 const signedTxs = await wallet.signTransactions({
                     transactions: Array.isArray(transaction) ? transaction : [transaction],
                 });
                 return Array.isArray(transaction) ? signedTxs : signedTxs[0];
-            }),
+            });
+        },
 
-        [authorizeSession],
+        [authorizeSession, ctx.identity],
     );
 
     /** @deprecated Use signAndSendTransactions instead. */


### PR DESCRIPTION
## Summary
- validate Mobile Wallet Adapter `identity.uri` schemes before React Native wallet authorization starts
- reject invalid underscore schemes locally with a clear error message
- add focused unit coverage for both React Native packages
- add a patch Changeset for the published packages

Closes #517

## Tests
- `pnpm --filter @wallet-ui/react-native-kit test:unit:node`
- `pnpm --filter @wallet-ui/react-native-web3js test:unit:node`
- `pnpm --filter @wallet-ui/react-native-kit test:lint`
- `pnpm --filter @wallet-ui/react-native-web3js test:lint`
- `pnpm --filter @wallet-ui/react-native-kit test:typecheck`
- `pnpm --filter @wallet-ui/react-native-web3js test:typecheck`
- `pnpm --filter @wallet-ui/react-native-kit test:prettier`
- `pnpm --filter @wallet-ui/react-native-web3js test:prettier`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mobile Wallet Adapter identity URI schemes are now validated before initiating wallet authorization flows; invalid schemes are rejected with a clear error to prevent failing wallet launches.

* **Tests**
  * Added unit tests to verify invalid identity URIs are rejected and that wallet launch is not attempted when validation fails.

* **Chores**
  * Patch release entries added for the affected packages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wallet-ui/wallet-ui/pull/518?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->