### PR TITLE
fix(test-config): include tsx in lint coverage

### DIFF
--- a/.changeset/lint-tsx-coverage.md
+++ b/.changeset/lint-tsx-coverage.md
@@ -1,0 +1,7 @@
+---
+"@wallet-ui/react": patch
+"@wallet-ui/react-native-kit": patch
+"@wallet-ui/react-native-web3js": patch
+---
+
+Stabilize provider initialization without render-time ref writes.

--- a/packages/react-native-kit/src/__tests__/mobile-wallet-provider-test.tsx
+++ b/packages/react-native-kit/src/__tests__/mobile-wallet-provider-test.tsx
@@ -1,12 +1,12 @@
 import { AppIdentity } from '@solana-mobile/mobile-wallet-adapter-protocol';
 import React, { type ReactNode, useContext } from 'react';
 
-import { act, renderHook } from '../test-utils/react-test-renderer';
 import { createAsyncStorageCache } from '../async-storage-cache';
 import type { Cache } from '../cache';
 import type { Client } from '../client';
 import { MobileWalletProvider, MobileWalletProviderContext } from '../mobile-wallet-provider';
 import { createCache } from '../test-utils/fixtures';
+import { act, renderHook } from '../test-utils/react-test-renderer';
 import type { WalletAuthorization } from '../use-authorization';
 
 jest.mock('../async-storage-cache', () => ({
@@ -53,7 +53,9 @@ describe('MobileWalletProvider', () => {
         expect(hook.result.chain).toBe(CLUSTER.id);
         expect(hook.result.client).toBe(client);
         expect(hook.result.identity).toBe(IDENTITY);
-        expect(hook.result.store).toEqual(expect.objectContaining({ fetch: expect.any(Function), persist: expect.any(Function) }));
+        expect(hook.result.store).toEqual(
+            expect.objectContaining({ fetch: expect.any(Function), persist: expect.any(Function) }),
+        );
     });
 
     it('creates a default cache when one is not provided', async () => {

--- a/packages/react-native-kit/src/__tests__/use-authorization-store-test.tsx
+++ b/packages/react-native-kit/src/__tests__/use-authorization-store-test.tsx
@@ -1,6 +1,6 @@
-import { act, renderHook } from '../test-utils/react-test-renderer';
 import { createAuthorizationStore } from '../authorization-store';
 import { createCache, createExpectedAuthorization } from '../test-utils/fixtures';
+import { act, renderHook } from '../test-utils/react-test-renderer';
 import { useAuthorizationStore } from '../use-authorization-store';
 
 describe('useAuthorizationStore', () => {

--- a/packages/react-native-kit/src/__tests__/use-authorization-test.tsx
+++ b/packages/react-native-kit/src/__tests__/use-authorization-test.tsx
@@ -1,16 +1,14 @@
 import {
     AppIdentity,
-    AuthorizeAPI,
     Chain,
-    DeauthorizeAPI,
     SignInPayload,
     SolanaMobileWalletAdapterProtocolError,
     SolanaMobileWalletAdapterProtocolErrorCode,
 } from '@solana-mobile/mobile-wallet-adapter-protocol';
 
 import {
-    createAuthorizedAccount,
     createAuthorizationResult,
+    createAuthorizedAccount,
     createExpectedAccount,
     createExpectedAuthorization,
     createExpectedSignInOutput,
@@ -62,7 +60,7 @@ describe('useAuthorization', () => {
             ),
         });
 
-        const selectedAccount = await authorization.authorizeSession(wallet as AuthorizeAPI);
+        const selectedAccount = await authorization.authorizeSession(wallet);
 
         expect(wallet.authorize).toHaveBeenCalledWith({
             auth_token: 'cached-auth-token',
@@ -115,7 +113,7 @@ describe('useAuthorization', () => {
                 ),
         });
 
-        await authorization.authorizeSession(wallet as AuthorizeAPI);
+        await authorization.authorizeSession(wallet);
 
         expect(wallet.authorize.mock.calls).toEqual([
             [
@@ -163,7 +161,7 @@ describe('useAuthorization', () => {
             ),
         });
 
-        const output = await authorization.authorizeSessionWithSignIn(wallet as AuthorizeAPI, signInPayload);
+        const output = await authorization.authorizeSessionWithSignIn(wallet, signInPayload);
 
         expect(wallet.authorize).toHaveBeenCalledWith({
             auth_token: 'cached-auth-token',
@@ -191,7 +189,7 @@ describe('useAuthorization', () => {
             deauthorize: jest.fn().mockResolvedValue(undefined),
         });
 
-        await authorization.deauthorizeSession(wallet as DeauthorizeAPI);
+        await authorization.deauthorizeSession(wallet);
 
         expect(wallet.deauthorize).toHaveBeenCalledWith({
             auth_token: 'cached-auth-token',

--- a/packages/react-native-kit/src/__tests__/use-mobile-wallet-test.tsx
+++ b/packages/react-native-kit/src/__tests__/use-mobile-wallet-test.tsx
@@ -4,8 +4,6 @@ import { resetAsyncStorageMock } from '../../../test-config/react-native-unit-te
 import { createExpectedAccount, FIRST_ADDRESS, FIRST_ADDRESS_BASE64 } from '../test-utils/fixtures';
 import { useMobileWallet } from '../use-mobile-wallet';
 
-let currentContext: unknown;
-
 const mockAppendTransactionMessageInstructions = jest.fn();
 const mockAuthorizeSession = jest.fn();
 const mockAuthorizeSessionWithSignIn = jest.fn();
@@ -18,6 +16,7 @@ const mockSetTransactionMessageFeePayerSigner = jest.fn();
 const mockSetTransactionMessageLifetimeUsingBlockhash = jest.fn();
 const mockSignAndSendTransactionMessageWithSigners = jest.fn();
 const mockTransact = jest.fn();
+const mockUseContext = jest.fn();
 const mockUseAuthorization = jest.fn();
 
 jest.mock('@react-native-async-storage/async-storage', () => ({
@@ -35,7 +34,7 @@ jest.mock('react', () => {
     return {
         ...actual,
         useCallback: (callback: unknown) => callback,
-        useContext: () => currentContext,
+        useContext: (...args: unknown[]) => mockUseContext(...args),
         useMemo: (factory: () => unknown) => factory(),
     };
 });
@@ -307,7 +306,7 @@ function useMobileWalletTestHarness({
     contextOverrides?: Record<string, unknown>;
     transportWallet?: ReturnType<typeof createTransportWallet>;
 } = {}) {
-    currentContext = createContextValue(contextOverrides);
+    mockUseContext.mockReturnValue(createContextValue(contextOverrides));
     resetAsyncStorageMock(AsyncStorage as unknown as Parameters<typeof resetAsyncStorageMock>[0]);
     mockAppendTransactionMessageInstructions.mockImplementation((instructions, transactionMessage) => ({
         instructions,

--- a/packages/react-native-kit/src/mobile-wallet-provider.tsx
+++ b/packages/react-native-kit/src/mobile-wallet-provider.tsx
@@ -1,6 +1,6 @@
 import { AppIdentity } from '@solana-mobile/mobile-wallet-adapter-protocol';
 import { SolanaCluster } from '@wallet-ui/core';
-import React, { createContext, type ReactNode, useEffect, useMemo, useRef } from 'react';
+import React, { createContext, type ReactNode, useEffect, useMemo, useState } from 'react';
 
 import { createAsyncStorageCache } from './async-storage-cache';
 import { AuthorizationStore, createAuthorizationStore } from './authorization-store';
@@ -31,11 +31,7 @@ export function MobileWalletProvider({
     const cache = useMemo(() => userCache ?? createAsyncStorageCache<WalletAuthorization>(), [userCache]);
     const client = useMemo(() => createClient(cluster), [createClient, cluster]);
 
-    const storeRef = useRef<AuthorizationStore | null>(null);
-    if (!storeRef.current) {
-        storeRef.current = createAuthorizationStore({ cache });
-    }
-    const store = storeRef.current;
+    const [store] = useState(() => createAuthorizationStore({ cache }));
 
     useEffect(() => {
         store.fetch().catch(console.error);

--- a/packages/react-native-web3js/src/__tests__/mobile-wallet-provider-test.tsx
+++ b/packages/react-native-web3js/src/__tests__/mobile-wallet-provider-test.tsx
@@ -2,11 +2,11 @@ import { Connection } from '@solana/web3.js';
 import { AppIdentity, Chain } from '@solana-mobile/mobile-wallet-adapter-protocol';
 import React, { type ReactNode, useContext } from 'react';
 
-import { act, renderHook } from '../test-utils/react-test-renderer';
 import { createAsyncStorageCache } from '../async-storage-cache';
 import type { Cache } from '../cache';
 import { MobileWalletProvider, MobileWalletProviderContext } from '../mobile-wallet-provider';
 import { createCache } from '../test-utils/fixtures';
+import { act, renderHook } from '../test-utils/react-test-renderer';
 import type { WalletAuthorization } from '../use-authorization';
 
 jest.mock('../async-storage-cache', () => ({
@@ -46,7 +46,9 @@ describe('MobileWalletProvider', () => {
         expect(hook.result.connection).toBeInstanceOf(Connection);
         expect(hook.result.connection.rpcEndpoint).toBe(ENDPOINT);
         expect(hook.result.identity).toBe(IDENTITY);
-        expect(hook.result.store).toEqual(expect.objectContaining({ fetch: expect.any(Function), persist: expect.any(Function) }));
+        expect(hook.result.store).toEqual(
+            expect.objectContaining({ fetch: expect.any(Function), persist: expect.any(Function) }),
+        );
     });
 
     it('creates a default cache when one is not provided', async () => {
@@ -73,11 +75,7 @@ describe('MobileWalletProvider', () => {
     });
 });
 
-function createProviderWrapper({
-    cache,
-}: {
-    cache?: Cache<WalletAuthorization | undefined>;
-}) {
+function createProviderWrapper({ cache }: { cache?: Cache<WalletAuthorization | undefined> }) {
     return function ProviderWrapper({ children }: { children: unknown }) {
         return (
             <MobileWalletProvider cache={cache} chain={CHAIN} endpoint={ENDPOINT} identity={IDENTITY}>

--- a/packages/react-native-web3js/src/__tests__/use-authorization-store-test.tsx
+++ b/packages/react-native-web3js/src/__tests__/use-authorization-store-test.tsx
@@ -1,6 +1,6 @@
-import { act, renderHook } from '../test-utils/react-test-renderer';
 import { createAuthorizationStore } from '../authorization-store';
 import { createCache, createExpectedAuthorization } from '../test-utils/fixtures';
+import { act, renderHook } from '../test-utils/react-test-renderer';
 import { useAuthorizationStore } from '../use-authorization-store';
 
 describe('useAuthorizationStore', () => {

--- a/packages/react-native-web3js/src/__tests__/use-authorization-test.tsx
+++ b/packages/react-native-web3js/src/__tests__/use-authorization-test.tsx
@@ -1,8 +1,6 @@
 import {
     AppIdentity,
-    AuthorizeAPI,
     Chain,
-    DeauthorizeAPI,
     SignInPayload,
     SolanaMobileWalletAdapterProtocolError,
     SolanaMobileWalletAdapterProtocolErrorCode,
@@ -10,8 +8,8 @@ import {
 import { Buffer } from 'buffer';
 
 import {
-    createAuthorizedAccount,
     createAuthorizationResult,
+    createAuthorizedAccount,
     createExpectedAccount,
     createExpectedAuthorization,
     createExpectedSignInOutput,
@@ -67,7 +65,7 @@ describe('useAuthorization', () => {
             ),
         });
 
-        const selectedAccount = await authorization.authorizeSession(wallet as AuthorizeAPI);
+        const selectedAccount = await authorization.authorizeSession(wallet);
 
         expect(wallet.authorize).toHaveBeenCalledWith({
             auth_token: 'cached-auth-token',
@@ -120,7 +118,7 @@ describe('useAuthorization', () => {
                 ),
         });
 
-        await authorization.authorizeSession(wallet as AuthorizeAPI);
+        await authorization.authorizeSession(wallet);
 
         expect(wallet.authorize.mock.calls).toEqual([
             [
@@ -168,7 +166,7 @@ describe('useAuthorization', () => {
             ),
         });
 
-        const output = await authorization.authorizeSessionWithSignIn(wallet as AuthorizeAPI, signInPayload);
+        const output = await authorization.authorizeSessionWithSignIn(wallet, signInPayload);
 
         expect(wallet.authorize).toHaveBeenCalledWith({
             auth_token: 'cached-auth-token',
@@ -196,7 +194,7 @@ describe('useAuthorization', () => {
             deauthorize: jest.fn().mockResolvedValue(undefined),
         });
 
-        await authorization.deauthorizeSession(wallet as DeauthorizeAPI);
+        await authorization.deauthorizeSession(wallet);
 
         expect(wallet.deauthorize).toHaveBeenCalledWith({
             auth_token: 'cached-auth-token',

--- a/packages/react-native-web3js/src/__tests__/use-mobile-wallet-test.tsx
+++ b/packages/react-native-web3js/src/__tests__/use-mobile-wallet-test.tsx
@@ -5,13 +5,12 @@ import { resetAsyncStorageMock } from '../../../test-config/react-native-unit-te
 import { createExpectedAccount, FIRST_ADDRESS_BASE64 } from '../test-utils/fixtures';
 import { useMobileWallet } from '../use-mobile-wallet';
 
-let currentContext: unknown;
-
 const mockAuthorizeSession = jest.fn();
 const mockAuthorizeSessionWithSignIn = jest.fn();
 const mockDeauthorizeSession = jest.fn();
 const mockDeauthorizeSessions = jest.fn();
 const mockTransact = jest.fn();
+const mockUseContext = jest.fn();
 const mockUseAuthorization = jest.fn();
 
 jest.mock('@react-native-async-storage/async-storage', () => ({
@@ -29,7 +28,7 @@ jest.mock('react', () => {
     return {
         ...actual,
         useCallback: (callback: unknown) => callback,
-        useContext: () => currentContext,
+        useContext: (...args: unknown[]) => mockUseContext(...args),
         useMemo: (factory: () => unknown) => factory(),
     };
 });
@@ -189,7 +188,7 @@ function useMobileWalletTestHarness({
     contextOverrides?: Record<string, unknown>;
     transportWallet?: ReturnType<typeof createTransportWallet>;
 } = {}) {
-    currentContext = createContextValue(contextOverrides);
+    mockUseContext.mockReturnValue(createContextValue(contextOverrides));
     resetAsyncStorageMock(AsyncStorage as unknown as Parameters<typeof resetAsyncStorageMock>[0]);
     mockAuthorizeSession.mockResolvedValue(createExpectedAccount({ label: 'Primary' }));
     mockAuthorizeSessionWithSignIn.mockResolvedValue({

--- a/packages/react-native-web3js/src/mobile-wallet-provider.tsx
+++ b/packages/react-native-web3js/src/mobile-wallet-provider.tsx
@@ -1,6 +1,6 @@
 import { Commitment, Connection, ConnectionConfig } from '@solana/web3.js';
 import { AppIdentity, Chain } from '@solana-mobile/mobile-wallet-adapter-protocol';
-import React, { createContext, type ReactNode, useEffect, useMemo, useRef } from 'react';
+import React, { createContext, type ReactNode, useEffect, useMemo, useState } from 'react';
 
 import { createAsyncStorageCache } from './async-storage-cache';
 import { AuthorizationStore, createAuthorizationStore } from './authorization-store';
@@ -31,11 +31,7 @@ export function MobileWalletProvider({
     const connection = useMemo(() => new Connection(endpoint, commitmentOrConfig), [commitmentOrConfig, endpoint]);
     const cache = useMemo(() => userCache ?? createAsyncStorageCache<WalletAuthorization>(), [userCache]);
 
-    const storeRef = useRef<AuthorizationStore | null>(null);
-    if (!storeRef.current) {
-        storeRef.current = createAuthorizationStore({ cache });
-    }
-    const store = storeRef.current;
+    const [store] = useState(() => createAuthorizationStore({ cache }));
 
     useEffect(() => {
         store.fetch().catch(console.error);

--- a/packages/react/src/__tests__/wallet-ui-account-context-provider-actions-test.tsx
+++ b/packages/react/src/__tests__/wallet-ui-account-context-provider-actions-test.tsx
@@ -1,11 +1,6 @@
 import type { SolanaCluster } from '@wallet-ui/core';
 
-import {
-    createAccount,
-    createWallet,
-    type TestAccount,
-    type TestWallet,
-} from '../test-utils/wallet-ui-test-utils';
+import { createAccount, createWallet, type TestAccount, type TestWallet } from '../test-utils/wallet-ui-test-utils';
 
 const CLUSTER: SolanaCluster = {
     id: 'solana:testnet',
@@ -127,14 +122,12 @@ function renderProvider(cleanups: Array<() => void>, initialWallets: TestWallet[
         } = jest.requireActual('@nanostores/persistent');
         const { getTestStorage, useTestStorageEngine } = persistent;
         const { createStorageAccount } = jest.requireActual<typeof import('@wallet-ui/core')>('@wallet-ui/core');
-        const { act, create } =
-            jest.requireActual<typeof import('react-test-renderer')>('react-test-renderer');
+        const { act, create } = jest.requireActual<typeof import('react-test-renderer')>('react-test-renderer');
         const { WalletUiAccountContext } =
             jest.requireActual<typeof import('../wallet-ui-account-context')>('../wallet-ui-account-context');
-        const { WalletUiAccountContextProvider } =
-            jest.requireActual<typeof import('../wallet-ui-account-context-provider')>(
-                '../wallet-ui-account-context-provider',
-            );
+        const { WalletUiAccountContextProvider } = jest.requireActual<
+            typeof import('../wallet-ui-account-context-provider')
+        >('../wallet-ui-account-context-provider');
 
         let contextValue:
             | {

--- a/packages/react/src/__tests__/wallet-ui-account-context-provider-test.tsx
+++ b/packages/react/src/__tests__/wallet-ui-account-context-provider-test.tsx
@@ -2,12 +2,7 @@ import { createStorageAccount, type SolanaCluster } from '@wallet-ui/core';
 import React, { useContext } from 'react';
 import { act, create } from 'react-test-renderer';
 
-import {
-    createAccount,
-    createWallet,
-    type TestAccount,
-    type TestWallet,
-} from '../test-utils/wallet-ui-test-utils';
+import { createAccount, createWallet, type TestAccount, type TestWallet } from '../test-utils/wallet-ui-test-utils';
 import { WalletUiAccountContext } from '../wallet-ui-account-context';
 import { WalletUiAccountContextProvider } from '../wallet-ui-account-context-provider';
 

--- a/packages/react/src/__tests__/wallet-ui-cluster-context-provider-test.tsx
+++ b/packages/react/src/__tests__/wallet-ui-cluster-context-provider-test.tsx
@@ -46,9 +46,7 @@ describe('WalletUiClusterContextProvider', () => {
 
         expect(() =>
             act(() => {
-                create(
-                    <WalletUiClusterContextProvider clusters={[]} render={() => null} storage={storage} />,
-                );
+                create(<WalletUiClusterContextProvider clusters={[]} render={() => null} storage={storage} />);
             }),
         ).toThrow('No clusters provided');
     });
@@ -130,7 +128,7 @@ function renderProvider({
     let renderValue: typeof contextValue;
 
     function Probe() {
-        contextValue = useContext(WalletUiClusterContext) as typeof contextValue;
+        contextValue = useContext(WalletUiClusterContext);
         return null;
     }
 
@@ -141,7 +139,7 @@ function renderProvider({
             <WalletUiClusterContextProvider
                 clusters={clusters}
                 render={value => {
-                    renderValue = value as typeof renderValue;
+                    renderValue = value;
                     return <Probe />;
                 }}
                 storage={storage}

--- a/packages/react/src/__tests__/wallet-ui-components-test.tsx
+++ b/packages/react/src/__tests__/wallet-ui-components-test.tsx
@@ -1,24 +1,24 @@
 import type { UiWallet, UiWalletAccount } from '@wallet-standard/react';
 import React from 'react';
 import { act, create } from 'react-test-renderer';
+
 import { BaseDropdownItemType } from '../base-dropdown';
 import type { BaseModalProps } from '../base-modal';
+import { createAccount, createWallet } from '../test-utils/wallet-ui-test-utils';
 import type { BaseModalControl } from '../use-base-modal';
-
-import { type WalletUiAccountState, WalletUiAccountContext } from '../wallet-ui-account-context';
+import { WalletUiAccountContext, type WalletUiAccountState } from '../wallet-ui-account-context';
 import { WalletUiAccountGuard } from '../wallet-ui-account-guard';
-import { type WalletUiClusterContextValue, WalletUiClusterContext } from '../wallet-ui-cluster-context';
+import { WalletUiClusterContext, type WalletUiClusterContextValue } from '../wallet-ui-cluster-context';
 import { WalletUiClusterDropdown } from '../wallet-ui-cluster-dropdown';
 import { WalletUiDropdown } from '../wallet-ui-dropdown';
+import { WalletUiIcon } from '../wallet-ui-icon';
 import { WalletUiIconClose } from '../wallet-ui-icon-close';
 import { WalletUiIconNoWallet } from '../wallet-ui-icon-no-wallet';
-import { WalletUiIcon } from '../wallet-ui-icon';
 import { WalletUiLabel } from '../wallet-ui-label';
-import { WalletUiListButton } from '../wallet-ui-list-button';
 import { WalletUiList } from '../wallet-ui-list';
-import { WalletUiModalTrigger } from '../wallet-ui-modal-trigger';
+import { WalletUiListButton } from '../wallet-ui-list-button';
 import { WalletUiModal } from '../wallet-ui-modal';
-import { createAccount, createWallet } from '../test-utils/wallet-ui-test-utils';
+import { WalletUiModalTrigger } from '../wallet-ui-modal-trigger';
 
 const mockBaseModal = jest.fn();
 const mockUseBaseDropdown = jest.fn();
@@ -455,10 +455,7 @@ describe('WalletUiListButton', () => {
         const select = jest.fn(() => deferred.promise.catch(() => undefined));
         const renderer = render(
             cleanups,
-            <WalletUiListButton
-                select={select}
-                wallet={createUiWallet({ accounts: [account], name: 'Phantom' })}
-            />,
+            <WalletUiListButton select={select} wallet={createUiWallet({ accounts: [account], name: 'Phantom' })} />,
         );
 
         act(() => {
@@ -559,11 +556,7 @@ function createAccountContextValue({
     };
 }
 
-function createClusterContextValue({
-    setCluster,
-}: {
-    setCluster: jest.Mock;
-}): WalletUiClusterContextValue {
+function createClusterContextValue({ setCluster }: { setCluster: jest.Mock }): WalletUiClusterContextValue {
     return {
         cluster: {
             id: 'solana:devnet',
@@ -588,7 +581,7 @@ function createClusterContextValue({
 
 function createDeferred<T>() {
     let reject!: (reason?: unknown) => void;
-    let resolve!: (value: T | PromiseLike<T>) => void;
+    let resolve!: (value: PromiseLike<T> | T) => void;
 
     const promise = new Promise<T>((res, rej) => {
         reject = rej;
@@ -627,26 +620,14 @@ function createModalControl() {
     };
 }
 
-function createUiWallet({
-    accounts = [],
-    name,
-}: {
-    accounts?: UiWalletAccount[];
-    name: string;
-}): UiWallet {
+function createUiWallet({ accounts = [], name }: { accounts?: UiWalletAccount[]; name: string }): UiWallet {
     return createWallet({
         accounts: accounts as unknown as ReturnType<typeof createAccount>[],
         name,
     }) as unknown as UiWallet;
 }
 
-function createUiWalletAccount({
-    address,
-    walletName,
-}: {
-    address: string;
-    walletName: string;
-}): UiWalletAccount {
+function createUiWalletAccount({ address, walletName }: { address: string; walletName: string }): UiWalletAccount {
     return createAccount({ address, walletName }) as unknown as UiWalletAccount;
 }
 

--- a/packages/react/src/__tests__/wallet-ui-context-provider-test.tsx
+++ b/packages/react/src/__tests__/wallet-ui-context-provider-test.tsx
@@ -2,12 +2,7 @@ import type { SolanaCluster } from '@wallet-ui/core';
 import React, { useContext } from 'react';
 import { act, create } from 'react-test-renderer';
 
-import {
-    createAccount,
-    createWallet,
-    type TestAccount,
-    type TestWallet,
-} from '../test-utils/wallet-ui-test-utils';
+import { createAccount, createWallet, type TestAccount, type TestWallet } from '../test-utils/wallet-ui-test-utils';
 import { WalletUiAccountContext } from '../wallet-ui-account-context';
 import { WalletUiContext } from '../wallet-ui-context';
 import { WalletUiContextProvider } from '../wallet-ui-context-provider';

--- a/packages/react/src/__tests__/wallet-ui-hooks-test.tsx
+++ b/packages/react/src/__tests__/wallet-ui-hooks-test.tsx
@@ -4,7 +4,7 @@ import type { UiWallet, UiWalletAccount } from '@wallet-standard/react';
 import { BaseDropdownItemType } from '../base-dropdown';
 import { renderHook } from '../test-renderer';
 import { createAccount, createWallet } from '../test-utils/wallet-ui-test-utils';
-import { useWalletUiDropdown, ellipsify } from '../use-wallet-ui-dropdown';
+import { ellipsify, useWalletUiDropdown } from '../use-wallet-ui-dropdown';
 import { useWalletUiSigner } from '../use-wallet-ui-signer';
 import { useWalletUiWallet } from '../use-wallet-ui-wallet';
 
@@ -383,10 +383,10 @@ function createDropdownControl() {
 
 function stubWindowOpen(open: jest.Mock) {
     if (typeof window !== 'undefined') {
-        const spy = jest.spyOn(window, 'open').mockImplementation(((...args) => {
+        const spy = jest.spyOn(window, 'open').mockImplementation((...args) => {
             open(...args);
             return null;
-        }) as typeof window.open);
+        });
 
         return () => {
             spy.mockRestore();
@@ -429,13 +429,7 @@ function createUiWallet({
     };
 }
 
-function createUiWalletAccount({
-    address,
-    walletName,
-}: {
-    address: string;
-    walletName: string;
-}): UiWalletAccount {
+function createUiWalletAccount({ address, walletName }: { address: string; walletName: string }): UiWalletAccount {
     return createAccount({ address, walletName }) as unknown as UiWalletAccount;
 }
 

--- a/packages/react/src/__tests__/wallet-ui-test.tsx
+++ b/packages/react/src/__tests__/wallet-ui-test.tsx
@@ -2,12 +2,7 @@ import { createStorageAccount, createStorageCluster, type SolanaCluster } from '
 import React from 'react';
 import { act, create } from 'react-test-renderer';
 
-import {
-    createAccount,
-    createWallet,
-    type TestAccount,
-    type TestWallet,
-} from '../test-utils/wallet-ui-test-utils';
+import { createAccount, createWallet, type TestAccount, type TestWallet } from '../test-utils/wallet-ui-test-utils';
 import { useWalletUi } from '../use-wallet-ui';
 import { createWalletUiConfig } from '../wallet-ui';
 import { WalletUi } from '../wallet-ui';

--- a/packages/react/src/use-wallet-ui-dropdown.tsx
+++ b/packages/react/src/use-wallet-ui-dropdown.tsx
@@ -76,37 +76,34 @@ export function useWalletUiDropdown(): {
 
     const itemsWallets = useMemo(() => getDropdownItemsWallets({ connect, wallets }), [wallets, connect]);
 
-    const itemsConnected: BaseDropdownItem[] = useMemo(
-        () => {
-            const walletCanDisconnect =
-                isWalletFeatureAvailable(wallet, StandardConnect) && isWalletFeatureAvailable(wallet, StandardDisconnect);
+    const itemsConnected: BaseDropdownItem[] = useMemo(() => {
+        const walletCanDisconnect =
+            isWalletFeatureAvailable(wallet, StandardConnect) && isWalletFeatureAvailable(wallet, StandardDisconnect);
 
-            return [
-                {
-                    handler: async () => {
-                        copy();
-                        void (await Promise.resolve());
-                    },
-                    label: 'Copy Address',
-                    type: BaseDropdownItemType.WalletCopy,
-                    value: 'copy',
+        return [
+            {
+                handler: async () => {
+                    copy();
+                    void (await Promise.resolve());
                 },
-                {
-                    handler: async () => {
-                        disconnect();
-                        dropdown.close();
-                        await Promise.resolve();
-                    },
-                    label: 'Disconnect',
-                    type: walletCanDisconnect ? BaseDropdownItemType.WalletDisconnect : BaseDropdownItemType.Item,
-                    value: 'disconnect',
-                    wallet: walletCanDisconnect ? wallet : undefined,
+                label: 'Copy Address',
+                type: BaseDropdownItemType.WalletCopy,
+                value: 'copy',
+            },
+            {
+                handler: async () => {
+                    disconnect();
+                    dropdown.close();
+                    await Promise.resolve();
                 },
-                ...itemsWallets,
-            ];
-        },
-        [copy, disconnect, dropdown, wallet, itemsWallets],
-    );
+                label: 'Disconnect',
+                type: walletCanDisconnect ? BaseDropdownItemType.WalletDisconnect : BaseDropdownItemType.Item,
+                value: 'disconnect',
+                wallet: walletCanDisconnect ? wallet : undefined,
+            },
+            ...itemsWallets,
+        ];
+    }, [copy, disconnect, dropdown, wallet, itemsWallets]);
     const items = useMemo(() => {
         return connected ? itemsConnected : itemsWallets;
     }, [connected, itemsConnected, itemsWallets]);

--- a/packages/react/src/wallet-ui-account-context-provider.tsx
+++ b/packages/react/src/wallet-ui-account-context-provider.tsx
@@ -8,7 +8,7 @@ import {
     useWallets,
 } from '@wallet-standard/react';
 import { createStorageAccount, SolanaCluster, StorageAccount } from '@wallet-ui/core';
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 
 import { WalletUiAccountContext } from './wallet-ui-account-context';
 
@@ -48,8 +48,12 @@ export interface WalletUiAccountContextProviderProps {
  * sessions it will try to return that same wallet account, or at least one from the same brand of
  * wallet if the wallet from which it came is still in the Wallet Standard registry.
  */
-export function WalletUiAccountContextProvider({ children, cluster, storage }: WalletUiAccountContextProviderProps) {
-    storage = storage ?? createStorageAccount();
+export function WalletUiAccountContextProvider({
+    children,
+    cluster,
+    storage: providedStorage,
+}: WalletUiAccountContextProviderProps) {
+    const storage = useMemo(() => providedStorage ?? createStorageAccount(), [providedStorage]);
     const wallets = useWallets();
     const accountId = useStore(storage.value);
     const [account, setAccountInternal] = useState<UiWalletAccount | undefined>(() =>
@@ -70,35 +74,29 @@ export function WalletUiAccountContextProvider({ children, cluster, storage }: W
         [storage],
     );
 
-    useEffect(() => {
-        const savedWalletAccount = getSavedWalletAccount(wallets, accountId);
-        if (savedWalletAccount) {
-            setAccountInternal(savedWalletAccount);
-        }
-    }, [accountId, wallets]);
+    const savedWalletAccount = useMemo(() => getSavedWalletAccount(wallets, accountId), [accountId, wallets]);
+    const selectedAccount = account ?? savedWalletAccount;
     const walletAccount = useMemo(() => {
-        if (account) {
+        if (selectedAccount) {
             for (const uiWallet of wallets) {
                 for (const uiWalletAccount of uiWallet.accounts) {
-                    if (uiWalletAccountsAreSame(account, uiWalletAccount)) {
+                    if (uiWalletAccountsAreSame(selectedAccount, uiWalletAccount)) {
                         return uiWalletAccount;
                     }
                 }
-                if (uiWalletAccountBelongsToUiWallet(account, uiWallet) && uiWallet.accounts[0]) {
+                if (uiWalletAccountBelongsToUiWallet(selectedAccount, uiWallet) && uiWallet.accounts[0]) {
                     // If the selected account belongs to this connected wallet, at least, then
                     // select one of its accounts.
                     return uiWallet.accounts[0];
                 }
             }
         }
-    }, [account, wallets]);
-    useEffect(() => {
+    }, [selectedAccount, wallets]);
+    if (account && !walletAccount) {
         // If there is a selected wallet account but the wallet to which it belongs has since
         // disconnected, clear the selected wallet.
-        if (account && !walletAccount) {
-            setAccountInternal(undefined);
-        }
-    }, [account, walletAccount]);
+        setAccountInternal(undefined);
+    }
 
     const wallet = useMemo(() => {
         if (!walletAccount) {

--- a/packages/react/src/wallet-ui-cluster-context-provider.tsx
+++ b/packages/react/src/wallet-ui-cluster-context-provider.tsx
@@ -8,8 +8,12 @@ import {
     WalletUiClusterContextValue,
 } from './wallet-ui-cluster-context';
 
-export function WalletUiClusterContextProvider({ clusters, render, storage }: WalletUiClusterContextProviderProps) {
-    storage = storage ?? createStorageCluster();
+export function WalletUiClusterContextProvider({
+    clusters,
+    render,
+    storage: providedStorage,
+}: WalletUiClusterContextProviderProps) {
+    const storage = useMemo(() => providedStorage ?? createStorageCluster(), [providedStorage]);
     const clusterId = useStore(storage.value);
 
     if (!clusters.length) {

--- a/packages/test-config/jest-lint.config.js
+++ b/packages/test-config/jest-lint.config.js
@@ -4,7 +4,7 @@ const config = {
         name: 'ESLint',
     },
     runner: 'eslint',
-    testMatch: ['<rootDir>src/**/*.ts'],
+    testMatch: ['<rootDir>src/**/*.{ts,tsx}'],
     testPathIgnorePatterns: ['README.md'],
 };
 

--- a/turbo.json
+++ b/turbo.json
@@ -97,13 +97,7 @@
             "dependsOn": ["compile:js"]
         },
         "@wallet-ui/docs#build": {
-            "dependsOn": [
-                "^compile:js",
-                "^compile:typedefs",
-                "test:lint",
-                "test:prettier",
-                "test:typecheck"
-            ],
+            "dependsOn": ["^compile:js", "^compile:typedefs", "test:lint", "test:prettier", "test:typecheck"],
             "inputs": [
                 "$TURBO_DEFAULT$",
                 "astro.config.mjs",


### PR DESCRIPTION
Update the shared Jest ESLint config so package lint tasks run against both TS and TSX sources, matching the files covered by style:fix.

Fix the React and React Native lint failures exposed by that wider coverage, including stable provider initialization and test harness cleanup.