### PR TITLE
test(expo): add local validator account coverage

### DIFF
--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -53,7 +53,9 @@ jobs:
       - name: Test Expo Examples
         run: |
           pnpm --dir examples/expo-kit test
+          pnpm --dir examples/expo-kit test:live-with-test-validator
           pnpm --dir examples/expo-web3js test
+          pnpm --dir examples/expo-web3js test:live-with-test-validator
 
       - name: Smoke Test Expo Native Entries
         run: pnpm test:examples:native-entry

--- a/examples/expo-kit/jest.live.config.js
+++ b/examples/expo-kit/jest.live.config.js
@@ -1,0 +1,7 @@
+const baseConfig = require('./jest.config');
+
+module.exports = {
+    ...baseConfig,
+    testMatch: ['<rootDir>/test/**/*.live-test.ts?(x)'],
+    testTimeout: 60_000,
+};

--- a/examples/expo-kit/package.json
+++ b/examples/expo-kit/package.json
@@ -11,6 +11,7 @@
         "lint": "expo lint",
         "start": "expo start",
         "test": "jest -c ./jest.config.js --runInBand",
+        "test:live-with-test-validator": "jest -c ./jest.live.config.js --runInBand",
         "test:native-entry": "node ../../scripts/test-expo-native-entry-smoke.mjs @wallet-ui/react-native-kit",
         "web": "expo start --web"
     },

--- a/examples/expo-kit/test/app.local-validator.live-test.tsx
+++ b/examples/expo-kit/test/app.local-validator.live-test.tsx
@@ -1,0 +1,338 @@
+/* global afterEach, beforeEach, describe, expect, it, jest */
+
+import {
+    airdropFactory,
+    generateKeyPairSigner,
+    getAddressEncoder,
+    sendAndConfirmTransactionFactory,
+    signTransaction,
+} from '@solana/kit';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MobileWalletProvider, createDefaultClient, createSolanaLocalnet } from '@wallet-ui/react-native-kit';
+import React from 'react';
+import { act, create } from 'react-test-renderer';
+import HomeScreen from '@/app/index';
+import { AppConfig } from '@/constants/app-config';
+import { NetworkProvider } from '@/features/network/network-provider';
+
+const mockTransact = jest.fn();
+
+jest.mock(
+    '@solana-mobile/mobile-wallet-adapter-protocol-kit',
+    () => ({
+        transact: (...args: unknown[]) => mockTransact(...args),
+    }),
+    { virtual: true },
+);
+
+const AIRDROP_LAMPORTS = 2_000_000_000n;
+const LOCALNET = createSolanaLocalnet({ url: 'http://127.0.0.1:8899' });
+const SIGN_IN_RESULT = {
+    signature: 'sign-in-signature',
+    signed_message: 'sign-in-message',
+};
+const TEST_AUTH_TOKEN = 'local-validator-auth-token';
+const TEST_WALLET_LABEL = 'Local Validator Wallet';
+
+describe('expo-kit local validator integration', () => {
+    beforeEach(() => {
+        jest.spyOn(console, 'error').mockImplementation(() => {});
+        jest.spyOn(console, 'log').mockImplementation(() => {});
+        mockTransact.mockReset();
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    it('runs the app account operations through a funded local validator wallet', async () => {
+        const client = createDefaultClient(LOCALNET);
+        const signer = await generateKeyPairSigner();
+        const wallet = createLocalValidatorWallet({ client, signer });
+        await fundLocalValidatorWallet({ client, signer });
+
+        const renderer = await renderHomeScreen({ client, wallet });
+
+        await waitForCondition(() => hasText(renderer, 'Connected to Localnet'));
+
+        expect(hasText(renderer, 'Connected to Localnet')).toBe(true);
+
+        await pressButton(renderer, 'Connect');
+        await waitForCondition(() => hasText(renderer, `Connected to ${TEST_WALLET_LABEL}`));
+        await waitForCondition(() => hasText(renderer, 'Balance: 2 SOL'));
+
+        expect(wallet.authorize).toHaveBeenCalledWith(
+            expect.objectContaining({
+                auth_token: undefined,
+                chain: 'solana:localnet',
+                identity: AppConfig.identity,
+            }),
+        );
+
+        await pressButton(renderer, `Sign In with ${TEST_WALLET_LABEL}`);
+        await waitForCondition(() => wallet.authorize.mock.calls.length === 2);
+
+        expect(wallet.authorize).toHaveBeenNthCalledWith(
+            2,
+            expect.objectContaining({
+                auth_token: TEST_AUTH_TOKEN,
+                chain: 'solana:localnet',
+                sign_in_payload: {
+                    address: signer.address,
+                    chainId: 'solana:localnet',
+                    uri: AppConfig.identity.uri,
+                },
+            }),
+        );
+
+        await pressButton(renderer, 'Sign Message');
+        await waitForCondition(() => hasButton(renderer, 'Message Signed!'));
+
+        expect(wallet.signMessages).toHaveBeenCalledWith(
+            expect.objectContaining({
+                addresses: expect.any(Array),
+                payloads: [new TextEncoder().encode(`Signing a message with ${signer.address}`)],
+            }),
+        );
+
+        await pressButton(renderer, 'Sign Multiple Messages');
+        await waitForCondition(() => hasButton(renderer, '2 Messages Signed!'));
+
+        expect(wallet.signMessages).toHaveBeenCalledTimes(2);
+        expect(wallet.signMessages).toHaveBeenNthCalledWith(
+            2,
+            expect.objectContaining({
+                addresses: expect.any(Array),
+                payloads: expect.arrayContaining([
+                    new TextEncoder().encode(`Message 1 from ${signer.address}`),
+                    new TextEncoder().encode(`Message 2 from ${signer.address}`),
+                ]),
+            }),
+        );
+
+        await pressButton(renderer, 'Sign transaction');
+        await waitForCondition(() => wallet.signTransactions.mock.calls.length === 1);
+
+        expect(wallet.signTransactions).toHaveBeenCalledWith(
+            expect.objectContaining({
+                transactions: expect.any(Array),
+            }),
+        );
+
+        await pressButton(renderer, 'Send transaction');
+        await waitForCondition(() => wallet.signAndSendTransactions.mock.calls.length === 1);
+
+        expect(wallet.signAndSendTransactions).toHaveBeenNthCalledWith(
+            1,
+            expect.objectContaining({
+                minContextSlot: expect.any(Number),
+                transactions: expect.any(Array),
+            }),
+        );
+
+        await pressButton(renderer, 'Send Multiple Transactions');
+        await waitForCondition(() => hasButton(renderer, '2 Transactions Sent!'));
+
+        expect(findButton(renderer, '2 Transactions Sent!')).toBeTruthy();
+        expect(wallet.signAndSendTransactions).toHaveBeenNthCalledWith(
+            2,
+            expect.objectContaining({
+                minContextSlot: expect.any(Number),
+                transactions: expect.any(Array),
+            }),
+        );
+
+        await pressButton(renderer, 'Disconnect');
+        await waitForCondition(
+            () => hasButton(renderer, 'Connect') && !hasText(renderer, `Connected to ${TEST_WALLET_LABEL}`),
+        );
+
+        expect(findButton(renderer, 'Connect')).toBeTruthy();
+    });
+});
+
+async function fundLocalValidatorWallet({
+    client,
+    signer,
+}: {
+    client: ReturnType<typeof createDefaultClient>;
+    signer: Awaited<ReturnType<typeof generateKeyPairSigner>>;
+}) {
+    await airdropFactory(client)({
+        commitment: 'confirmed',
+        lamports: AIRDROP_LAMPORTS,
+        recipientAddress: signer.address,
+    });
+}
+
+function createLocalValidatorWallet({
+    client,
+    signer,
+}: {
+    client: ReturnType<typeof createDefaultClient>;
+    signer: Awaited<ReturnType<typeof generateKeyPairSigner>>;
+}) {
+    const addressBase64 = Buffer.from(getAddressEncoder().encode(signer.address)).toString('base64');
+    const sendAndConfirmTransaction = sendAndConfirmTransactionFactory(client);
+    const authorizationResult = {
+        accounts: [
+            {
+                address: addressBase64,
+                label: TEST_WALLET_LABEL,
+            },
+        ],
+        auth_token: TEST_AUTH_TOKEN,
+    };
+
+    return {
+        authorize: jest.fn(async ({ sign_in_payload }) => ({
+            ...authorizationResult,
+            ...(sign_in_payload ? { sign_in_result: SIGN_IN_RESULT } : {}),
+        })),
+        signAndSendTransactions: jest.fn(async ({ minContextSlot, transactions }) => {
+            return await Promise.all(
+                transactions.map(async transaction => {
+                    const signedTransaction = await signTransaction([signer.keyPair], transaction);
+
+                    await sendAndConfirmTransaction(signedTransaction, {
+                        commitment: 'confirmed',
+                        minContextSlot,
+                    });
+
+                    const signature = Object.values(signedTransaction.signatures)[0];
+
+                    if (!signature) {
+                        throw new Error('Expected signed transaction to contain a signature');
+                    }
+
+                    return signature;
+                }),
+            );
+        }),
+        signMessages: jest.fn(async ({ payloads }) => payloads),
+        signTransactions: jest.fn(async ({ transactions }) => transactions),
+    };
+}
+
+async function pressButton(renderer: any, title: string) {
+    await act(async () => {
+        const button = findButton(renderer, title);
+
+        if (button.props.disabled || button.props.accessibilityState?.disabled) {
+            throw new Error(`Button is disabled: ${title}`);
+        }
+
+        button.props.onPress();
+        await settle();
+    });
+}
+
+async function renderHomeScreen({
+    client,
+    wallet,
+}: {
+    client: ReturnType<typeof createDefaultClient>;
+    wallet: ReturnType<typeof createLocalValidatorWallet>;
+}) {
+    mockTransact.mockImplementation(async callback => await callback(wallet));
+
+    const queryClient = new QueryClient({
+        defaultOptions: {
+            queries: {
+                retry: false,
+            },
+        },
+    });
+
+    let renderer: any;
+
+    await act(async () => {
+        renderer = create(
+            <QueryClientProvider client={queryClient}>
+                <NetworkProvider
+                    networks={[LOCALNET]}
+                    render={({ selectedNetwork }) => (
+                        <MobileWalletProvider
+                            cache={createMemoryCache()}
+                            cluster={selectedNetwork}
+                            createClient={() => client}
+                            identity={AppConfig.identity}
+                        >
+                            <HomeScreen />
+                        </MobileWalletProvider>
+                    )}
+                />
+            </QueryClientProvider>,
+        );
+        await settle();
+    });
+
+    return renderer;
+}
+
+function createMemoryCache(initialValue?: unknown) {
+    let value = initialValue;
+
+    return {
+        clear: jest.fn(async () => {
+            value = undefined;
+        }),
+        get: jest.fn(async () => value),
+        set: jest.fn(async nextValue => {
+            value = nextValue;
+        }),
+    };
+}
+
+function findButton(renderer: any, title: string) {
+    const button = renderer.root.findAll(
+        node => typeof node.type === 'string' && node.type === 'Button' && node.props.title === title,
+    )[0];
+
+    if (!button) {
+        throw new Error(`Button not found: ${title}`);
+    }
+
+    return button;
+}
+
+function getNodeText(node: any): string {
+    return node.children
+        .map(child => {
+            if (typeof child === 'string') {
+                return child;
+            }
+            return getNodeText(child);
+        })
+        .join('');
+}
+
+function hasButton(renderer: any, title: string) {
+    return (
+        renderer.root.findAll(
+            node => typeof node.type === 'string' && node.type === 'Button' && node.props.title === title,
+        ).length > 0
+    );
+}
+
+function hasText(renderer: any, expected: string) {
+    return renderer.root.findAll(node => typeof node.type === 'string' && getNodeText(node) === expected).length > 0;
+}
+
+async function settle() {
+    await Promise.resolve();
+    await new Promise(resolve => setTimeout(resolve, 0));
+}
+
+async function waitForCondition(condition: () => boolean, timeoutMs = 10_000) {
+    const start = Date.now();
+
+    while (Date.now() - start < timeoutMs) {
+        if (condition()) {
+            return;
+        }
+        await settle();
+    }
+
+    throw new Error('Timed out waiting for condition');
+}

--- a/examples/expo-web3js/jest.live.config.js
+++ b/examples/expo-web3js/jest.live.config.js
@@ -1,0 +1,7 @@
+const baseConfig = require('./jest.config');
+
+module.exports = {
+    ...baseConfig,
+    testMatch: ['<rootDir>/test/**/*.live-test.ts?(x)'],
+    testTimeout: 60_000,
+};

--- a/examples/expo-web3js/package.json
+++ b/examples/expo-web3js/package.json
@@ -11,6 +11,7 @@
     "lint": "expo lint",
     "start": "expo start",
     "test": "jest -c ./jest.config.js --runInBand",
+    "test:live-with-test-validator": "jest -c ./jest.live.config.js --runInBand",
     "test:native-entry": "node ../../scripts/test-expo-native-entry-smoke.mjs @wallet-ui/react-native-web3js",
     "web": "expo start --web"
   },

--- a/examples/expo-web3js/test/app.local-validator.live-test.tsx
+++ b/examples/expo-web3js/test/app.local-validator.live-test.tsx
@@ -1,0 +1,305 @@
+/* global afterEach, beforeEach, describe, expect, it, jest */
+
+import { Connection, Keypair, LAMPORTS_PER_SOL } from '@solana/web3.js';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MobileWalletProvider, createSolanaLocalnet, toUint8Array } from '@wallet-ui/react-native-web3js';
+import React from 'react';
+import { act, create } from 'react-test-renderer';
+import HomeScreen from '@/app/index';
+import { AppConfig } from '@/constants/app-config';
+import { NetworkProvider } from '@/features/network/network-provider';
+
+const mockTransact = jest.fn();
+
+jest.mock(
+    '@solana-mobile/mobile-wallet-adapter-protocol-web3js',
+    () => ({
+        transact: (...args: unknown[]) => mockTransact(...args),
+    }),
+    { virtual: true },
+);
+
+const AIRDROP_LAMPORTS = 2 * LAMPORTS_PER_SOL;
+const LOCALNET = createSolanaLocalnet({ url: 'http://127.0.0.1:8899' });
+const SIGN_IN_RESULT = {
+    signature: 'sign-in-signature',
+    signed_message: 'sign-in-message',
+};
+const TEST_AUTH_TOKEN = 'local-validator-auth-token';
+const TEST_WALLET_LABEL = 'Local Validator Wallet';
+
+describe('expo-web3js local validator integration', () => {
+    beforeEach(() => {
+        jest.spyOn(console, 'error').mockImplementation(() => {});
+        jest.spyOn(console, 'log').mockImplementation(() => {});
+        mockTransact.mockReset();
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    it('runs the app account operations through a funded local validator wallet', async () => {
+        const connection = new Connection(LOCALNET.url, 'confirmed');
+        const keypair = Keypair.generate();
+        const wallet = createLocalValidatorWallet({ connection, keypair });
+        await fundLocalValidatorWallet({ connection, keypair });
+
+        const renderer = await renderHomeScreen({ wallet });
+
+        await waitForCondition(() => hasText(renderer, 'Connected to Localnet'));
+
+        expect(hasText(renderer, 'Connected to Localnet')).toBe(true);
+
+        await pressButton(renderer, 'Connect');
+        await waitForCondition(() => hasText(renderer, `Connected to ${TEST_WALLET_LABEL}`));
+        await waitForCondition(() => hasText(renderer, 'Balance: 2 SOL'));
+
+        expect(wallet.authorize).toHaveBeenCalledWith(
+            expect.objectContaining({
+                auth_token: undefined,
+                chain: 'solana:localnet',
+                identity: AppConfig.identity,
+            }),
+        );
+
+        await pressButton(renderer, `Sign In with ${TEST_WALLET_LABEL}`);
+        await waitForCondition(() => wallet.authorize.mock.calls.length === 2);
+
+        expect(wallet.authorize).toHaveBeenNthCalledWith(
+            2,
+            expect.objectContaining({
+                auth_token: TEST_AUTH_TOKEN,
+                chain: 'solana:localnet',
+                sign_in_payload: {
+                    address: keypair.publicKey.toString(),
+                    uri: AppConfig.identity.uri,
+                },
+            }),
+        );
+
+        await pressButton(renderer, 'Sign Message');
+        await waitForCondition(() => hasButton(renderer, 'Message Signed!'));
+
+        expect(wallet.signMessages).toHaveBeenCalledWith(
+            expect.objectContaining({
+                addresses: expect.any(Array),
+                payloads: [new TextEncoder().encode(`Signing a message with ${keypair.publicKey.toString()}`)],
+            }),
+        );
+
+        await pressButton(renderer, 'Sign Multiple Messages');
+        await waitForCondition(() => hasButton(renderer, '2 Messages Signed!'));
+
+        expect(wallet.signMessages).toHaveBeenCalledTimes(2);
+        expect(wallet.signMessages).toHaveBeenNthCalledWith(
+            2,
+            expect.objectContaining({
+                addresses: expect.any(Array),
+                payloads: expect.arrayContaining([
+                    toUint8Array(`Message 1 from ${keypair.publicKey.toString()}`),
+                    toUint8Array(`Message 2 from ${keypair.publicKey.toString()}`),
+                ]),
+            }),
+        );
+
+        await pressButton(renderer, 'Sign transaction');
+        await waitForCondition(() => wallet.signTransactions.mock.calls.length === 1);
+
+        expect(wallet.signTransactions).toHaveBeenCalledWith(
+            expect.objectContaining({
+                transactions: expect.any(Array),
+            }),
+        );
+
+        await pressButton(renderer, 'Send transaction');
+        await waitForCondition(() => wallet.signAndSendTransactions.mock.calls.length === 1);
+
+        expect(wallet.signAndSendTransactions).toHaveBeenNthCalledWith(
+            1,
+            expect.objectContaining({
+                minContextSlot: expect.any(Number),
+                transactions: expect.any(Array),
+            }),
+        );
+
+        await pressButton(renderer, 'Send Multiple Transactions');
+        await waitForCondition(() => hasButton(renderer, '2 Transactions Sent!'));
+
+        expect(findButton(renderer, '2 Transactions Sent!')).toBeTruthy();
+        expect(wallet.signAndSendTransactions).toHaveBeenNthCalledWith(
+            2,
+            expect.objectContaining({
+                minContextSlot: expect.any(Number),
+                transactions: expect.any(Array),
+            }),
+        );
+
+        await pressButton(renderer, 'Disconnect');
+        await waitForCondition(
+            () => hasButton(renderer, 'Connect') && !hasText(renderer, `Connected to ${TEST_WALLET_LABEL}`),
+        );
+
+        expect(findButton(renderer, 'Connect')).toBeTruthy();
+    });
+});
+
+async function fundLocalValidatorWallet({ connection, keypair }: { connection: Connection; keypair: Keypair }) {
+    const latestBlockhash = await connection.getLatestBlockhash();
+    const signature = await connection.requestAirdrop(keypair.publicKey, AIRDROP_LAMPORTS);
+
+    await connection.confirmTransaction({ signature, ...latestBlockhash }, 'confirmed');
+}
+
+function createLocalValidatorWallet({ connection, keypair }: { connection: Connection; keypair: Keypair }) {
+    const addressBase64 = Buffer.from(keypair.publicKey.toBytes()).toString('base64');
+    const authorizationResult = {
+        accounts: [
+            {
+                address: addressBase64,
+                label: TEST_WALLET_LABEL,
+            },
+        ],
+        auth_token: TEST_AUTH_TOKEN,
+    };
+
+    return {
+        authorize: jest.fn(async ({ sign_in_payload }) => ({
+            ...authorizationResult,
+            ...(sign_in_payload ? { sign_in_result: SIGN_IN_RESULT } : {}),
+        })),
+        signAndSendTransactions: jest.fn(async ({ minContextSlot, transactions }) => {
+            return await Promise.all(
+                transactions.map(async transaction => {
+                    transaction.sign([keypair]);
+                    return await connection.sendRawTransaction(transaction.serialize(), { minContextSlot });
+                }),
+            );
+        }),
+        signMessages: jest.fn(async ({ payloads }) => payloads),
+        signTransactions: jest.fn(async ({ transactions }) => {
+            for (const transaction of transactions) {
+                transaction.sign([keypair]);
+            }
+
+            return transactions;
+        }),
+    };
+}
+
+async function pressButton(renderer: any, title: string) {
+    await act(async () => {
+        const button = findButton(renderer, title);
+
+        if (button.props.disabled || button.props.accessibilityState?.disabled) {
+            throw new Error(`Button is disabled: ${title}`);
+        }
+
+        button.props.onPress();
+        await settle();
+    });
+}
+
+async function renderHomeScreen({ wallet }: { wallet: ReturnType<typeof createLocalValidatorWallet> }) {
+    mockTransact.mockImplementation(async callback => await callback(wallet));
+
+    const queryClient = new QueryClient({
+        defaultOptions: {
+            queries: {
+                retry: false,
+            },
+        },
+    });
+
+    let renderer: any;
+
+    await act(async () => {
+        renderer = create(
+            <QueryClientProvider client={queryClient}>
+                <NetworkProvider
+                    networks={[LOCALNET]}
+                    render={({ chain, endpoint }) => (
+                        <MobileWalletProvider
+                            cache={createMemoryCache()}
+                            chain={chain}
+                            endpoint={endpoint}
+                            identity={AppConfig.identity}
+                        >
+                            <HomeScreen />
+                        </MobileWalletProvider>
+                    )}
+                />
+            </QueryClientProvider>,
+        );
+        await settle();
+    });
+
+    return renderer;
+}
+
+function createMemoryCache(initialValue?: unknown) {
+    let value = initialValue;
+
+    return {
+        clear: jest.fn(async () => {
+            value = undefined;
+        }),
+        get: jest.fn(async () => value),
+        set: jest.fn(async nextValue => {
+            value = nextValue;
+        }),
+    };
+}
+
+function findButton(renderer: any, title: string) {
+    const button = renderer.root.findAll(
+        node => typeof node.type === 'string' && node.type === 'Button' && node.props.title === title,
+    )[0];
+
+    if (!button) {
+        throw new Error(`Button not found: ${title}`);
+    }
+
+    return button;
+}
+
+function getNodeText(node: any): string {
+    return node.children
+        .map(child => {
+            if (typeof child === 'string') {
+                return child;
+            }
+            return getNodeText(child);
+        })
+        .join('');
+}
+
+function hasButton(renderer: any, title: string) {
+    return (
+        renderer.root.findAll(
+            node => typeof node.type === 'string' && node.type === 'Button' && node.props.title === title,
+        ).length > 0
+    );
+}
+
+function hasText(renderer: any, expected: string) {
+    return renderer.root.findAll(node => typeof node.type === 'string' && getNodeText(node) === expected).length > 0;
+}
+
+async function settle() {
+    await Promise.resolve();
+    await new Promise(resolve => setTimeout(resolve, 0));
+}
+
+async function waitForCondition(condition: () => boolean, timeoutMs = 10_000) {
+    const start = Date.now();
+
+    while (Date.now() - start < timeoutMs) {
+        if (condition()) {
+            return;
+        }
+        await settle();
+    }
+
+    throw new Error('Timed out waiting for condition');
+}

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
         "test": "turbo run --concurrency=${TURBO_CONCURRENCY:-95.84%} test:unit:browser test:unit:node && pnpm test:examples",
         "test:coverage:packages": "node ./scripts/test-coverage-published-packages.mjs",
         "test:examples": "pnpm --dir examples/expo-kit test && pnpm --dir examples/expo-web3js test",
+        "test:examples:live-with-test-validator": "pnpm --dir examples/expo-kit test:live-with-test-validator && pnpm --dir examples/expo-web3js test:live-with-test-validator",
         "test:examples:native-entry": "pnpm --dir examples/expo-kit test:native-entry && pnpm --dir examples/expo-web3js test:native-entry",
         "test:live-with-test-validator": "turbo run --concurrency=${TURBO_CONCURRENCY:-95.84%} test:live-with-test-validator",
         "test:live-with-test-validator:setup": "./scripts/setup-test-validator.sh"


### PR DESCRIPTION
Adds live Jest coverage for the Expo kit and web3js examples that mounts each app, injects a funded dummy MWA wallet, and runs the account operation flow against localnet.

Coverage now includes:

- connect
- balance loading
- sign-in
- single-message signing
- multi-message signing
- transaction signing
- single transaction sending
- multiple transaction sending
- disconnect

The PR also wires the live example scripts into the PR workflow after the shared Solana test validator starts.

Part of #520