### PR TITLE
feat(react): add QR code component

### DIFF
--- a/.changeset/wallet-ui-react-qr-code.md
+++ b/.changeset/wallet-ui-react-qr-code.md
@@ -1,0 +1,5 @@
+---
+'@wallet-ui/react': minor
+---
+
+Add a WalletUiQrCode component for rendering QR codes from React.

--- a/packages/playground-react/src/playground/wallet-ui/playground-wallet-ui-qr-code.tsx
+++ b/packages/playground-react/src/playground/wallet-ui/playground-wallet-ui-qr-code.tsx
@@ -1,0 +1,73 @@
+import { WalletUiQrCode } from '@wallet-ui/react';
+import React from 'react';
+
+import { UiGroup } from '../../ui/';
+
+const QR_CODE_STYLE: React.CSSProperties = {
+    display: 'block',
+    height: 144,
+    width: 144,
+};
+const SOLANA_LOGO_MARK_SVG = `<svg width="101" height="88" viewBox="0 0 101 88" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M100.48 69.3817L83.8068 86.8015C83.4444 87.1799 83.0058 87.4816 82.5185 87.6878C82.0312 87.894 81.5055 88.0003 80.9743 88H1.93563C1.55849 88 1.18957 87.8926 0.874202 87.6912C0.558829 87.4897 0.31074 87.2029 0.160416 86.8659C0.0100923 86.529 -0.0359181 86.1566 0.0280382 85.7945C0.0919944 85.4324 0.263131 85.0964 0.520422 84.8278L17.2061 67.408C17.5676 67.0306 18.0047 66.7295 18.4904 66.5234C18.9762 66.3172 19.5002 66.2104 20.0301 66.2095H99.0644C99.4415 66.2095 99.8104 66.3169 100.126 66.5183C100.441 66.7198 100.689 67.0067 100.84 67.3436C100.99 67.6806 101.036 68.0529 100.972 68.415C100.908 68.7771 100.737 69.1131 100.48 69.3817ZM83.8068 34.3032C83.4444 33.9248 83.0058 33.6231 82.5185 33.4169C82.0312 33.2108 81.5055 33.1045 80.9743 33.1048H1.93563C1.55849 33.1048 1.18957 33.2121 0.874202 33.4136C0.558829 33.6151 0.31074 33.9019 0.160416 34.2388C0.0100923 34.5758 -0.0359181 34.9482 0.0280382 35.3103C0.0919944 35.6723 0.263131 36.0083 0.520422 36.277L17.2061 53.6968C17.5676 54.0742 18.0047 54.3752 18.4904 54.5814C18.9762 54.7875 19.5002 54.8944 20.0301 54.8952H99.0644C99.4415 54.8952 99.8104 54.7879 100.126 54.5864C100.441 54.3849 100.689 54.0981 100.84 53.7612C100.99 53.4242 101.036 53.0518 100.972 52.6897C100.908 52.3277 100.737 51.9917 100.48 51.723L83.8068 34.3032ZM1.93563 21.7905H80.9743C81.5055 21.7907 82.0312 21.6845 82.5185 21.4783C83.0058 21.2721 83.4444 20.9704 83.8068 20.592L100.48 3.17219C100.737 2.90357 100.908 2.56758 100.972 2.2055C101.036 1.84342 100.99 1.47103 100.84 1.13408C100.689 0.79713 100.441 0.510296 100.126 0.308823C99.8104 0.107349 99.4415 1.24074e-05 99.0644 0L20.0301 0C19.5002 0.000878397 18.9762 0.107699 18.4904 0.313848C18.0047 0.519998 17.5676 0.821087 17.2061 1.19848L0.524723 18.6183C0.267681 18.8866 0.0966198 19.2223 0.0325185 19.5839C-0.0315829 19.9456 0.0140624 20.3177 0.163856 20.6545C0.31365 20.9913 0.561081 21.2781 0.875804 21.4799C1.19053 21.6817 1.55886 21.7896 1.93563 21.7905Z" fill="url(#paint0_linear_174_4403)"/>
+<defs>
+<linearGradient id="paint0_linear_174_4403" x1="8.52558" y1="90.0973" x2="88.9933" y2="-3.01622" gradientUnits="userSpaceOnUse">
+<stop offset="0.08" stop-color="#9945FF"/>
+<stop offset="0.3" stop-color="#8752F3"/>
+<stop offset="0.5" stop-color="#5497D5"/>
+<stop offset="0.6" stop-color="#43B4CA"/>
+<stop offset="0.72" stop-color="#28E0B9"/>
+<stop offset="0.97" stop-color="#19FB9B"/>
+</linearGradient>
+</defs>
+</svg>`;
+const WALLET_ADDRESS = '11111111111111111111111111111111';
+const WALLET_UI_LOGO_SVG = `<svg width="1024" height="1024" viewBox="0 0 1024 1024" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect width="1024" height="1024" fill="#2B7FFF"/>
+<path d="M289.875 760.625L141 263H306L379.125 536.375L429 327.5L493.875 563.75L440.25 760.625H289.875ZM572.625 760.625L436.125 263H603.375L730.875 760.625H572.625ZM748.5 734.75L681 469.625L732.375 263H883.5L748.5 734.75Z" fill="white"/>
+</svg>`;
+
+const SOLANA_LOGO_MARK_HREF = `data:image/svg+xml,${encodeURIComponent(SOLANA_LOGO_MARK_SVG)}`;
+const WALLET_UI_LOGO_HREF = `data:image/svg+xml,${encodeURIComponent(WALLET_UI_LOGO_SVG)}`;
+
+export function PlaygroundWalletUiQrCode() {
+    return (
+        <UiGroup style={{ alignItems: 'flex-start', flexWrap: 'wrap' }}>
+            <WalletUiQrCode
+                height={144}
+                style={QR_CODE_STYLE}
+                title="Wallet address QR code"
+                value={WALLET_ADDRESS}
+                width={144}
+            />
+            <WalletUiQrCode
+                backgroundColor="#f8fafc"
+                foregroundColor="#111827"
+                height={144}
+                logo={{
+                    backgroundColor: '#ffffff',
+                    href: WALLET_UI_LOGO_HREF,
+                    size: 0.2,
+                }}
+                style={QR_CODE_STYLE}
+                title="Wallet UI logo wallet address QR code"
+                value={WALLET_ADDRESS}
+                width={144}
+            />
+            <WalletUiQrCode
+                backgroundColor="#ffffff"
+                foregroundColor="#111827"
+                height={144}
+                logo={{
+                    backgroundColor: '#ffffff',
+                    href: SOLANA_LOGO_MARK_HREF,
+                    size: 0.2,
+                }}
+                style={QR_CODE_STYLE}
+                title="Solana logo wallet address QR code"
+                value={WALLET_ADDRESS}
+                width={144}
+            />
+        </UiGroup>
+    );
+}

--- a/packages/playground-react/src/playground/wallet-ui/playground-wallet-ui.tsx
+++ b/packages/playground-react/src/playground/wallet-ui/playground-wallet-ui.tsx
@@ -17,6 +17,7 @@ import { PlaygroundWalletUiList } from './playground-wallet-ui-list';
 import { PlaygroundWalletUiListButton } from './playground-wallet-ui-list-button';
 import { PlaygroundWalletUiModal } from './playground-wallet-ui-modal';
 import { PlaygroundWalletUiProvider } from './playground-wallet-ui-provider';
+import { PlaygroundWalletUiQrCode } from './playground-wallet-ui-qr-code';
 
 const cards = {
     BaseButton: <PlaygroundBaseButton />,
@@ -32,6 +33,7 @@ const cards = {
     WalletUiListButton: <PlaygroundWalletUiListButton />,
     WalletUiModal: <PlaygroundWalletUiModal />,
     WalletUiProvider: <PlaygroundWalletUiProvider />,
+    WalletUiQrCode: <PlaygroundWalletUiQrCode />,
 };
 
 export function PlaygroundWalletUi() {

--- a/packages/react/src/__tests__/wallet-ui-components-test.tsx
+++ b/packages/react/src/__tests__/wallet-ui-components-test.tsx
@@ -21,12 +21,14 @@ import { WalletUiList } from '../wallet-ui-list';
 import { WalletUiListButton } from '../wallet-ui-list-button';
 import { WalletUiModal } from '../wallet-ui-modal';
 import { WalletUiModalTrigger } from '../wallet-ui-modal-trigger';
+import { WalletUiQrCode } from '../wallet-ui-qr-code';
 
 const mockBaseModal = vi.fn();
 const mockUseBaseDropdown = vi.fn();
 const mockUseWalletUiWallet = vi.fn();
 const mockUseWalletUiDropdown = vi.fn();
 const TEST_ICON = 'data:image/png;base64,ZmFrZQ==';
+const TEST_WALLET_ADDRESS = '11111111111111111111111111111111';
 
 afterEach(() => {
     mockBaseModal.mockReset();
@@ -533,6 +535,91 @@ describe('WalletUiModalTrigger', () => {
 
         expect(button.children).toContain('Select Wallet');
         expect(modal.open).toHaveBeenCalled();
+    });
+});
+
+describe('WalletUiQrCode', () => {
+    const cleanups: Array<() => void> = [];
+
+    afterEach(() => {
+        for (const cleanup of cleanups.splice(0).reverse()) {
+            cleanup();
+        }
+    });
+
+    it('renders an accessible QR code svg when a title is provided', () => {
+        const renderer = render(
+            cleanups,
+            <WalletUiQrCode
+                className="qr-code"
+                foregroundColor="#111827"
+                title="Wallet address"
+                value={TEST_WALLET_ADDRESS}
+            />,
+        );
+        const svg = renderer.root.findByProps({ 'data-wu': 'wallet-ui-qr-code' });
+        const background = renderer.root.findByType('rect');
+        const foreground = renderer.root.findByType('path');
+        const title = renderer.root.findByType('title');
+
+        expect(background.props.fill).toBe('#fff');
+        expect(background.props.height).toBe(29);
+        expect(foreground.props.d).toContain('M4 4h1v1H4z');
+        expect(foreground.props.fill).toBe('#111827');
+        expect(svg.props['aria-labelledby']).toBe(title.props.id);
+        expect(svg.props.className).toBe('qr-code');
+        expect(svg.props.role).toBe('img');
+        expect(svg.props.viewBox).toBe('0 0 29 29');
+        expect(title.children).toEqual(['Wallet address']);
+    });
+
+    it('hides an untitled QR code svg from assistive technology', () => {
+        const renderer = render(cleanups, <WalletUiQrCode value={TEST_WALLET_ADDRESS} />);
+        const svg = renderer.root.findByProps({ 'data-wu': 'wallet-ui-qr-code' });
+
+        expect(renderer.root.findAllByType('title')).toHaveLength(0);
+        expect(svg.props['aria-hidden']).toBe(true);
+        expect(svg.props.role).toBeUndefined();
+    });
+
+    it('preserves a custom aria-labelledby value', () => {
+        const renderer = render(
+            cleanups,
+            <WalletUiQrCode aria-labelledby="custom-qr-label" title="Wallet address" value={TEST_WALLET_ADDRESS} />,
+        );
+        const svg = renderer.root.findByProps({ 'data-wu': 'wallet-ui-qr-code' });
+
+        expect(svg.props['aria-labelledby']).toBe('custom-qr-label');
+    });
+
+    it('renders a centered logo with capped size', () => {
+        const renderer = render(
+            cleanups,
+            <WalletUiQrCode
+                backgroundColor="#f8fafc"
+                logo={{
+                    backgroundColor: '#ffffff',
+                    href: TEST_ICON,
+                    size: 0.5,
+                }}
+                value={TEST_WALLET_ADDRESS}
+            />,
+        );
+        const image = renderer.root.findByType('image');
+        const logoBackground = renderer.root.findAllByType('rect')[1];
+        const svg = renderer.root.findByProps({ 'data-wu': 'wallet-ui-qr-code' });
+
+        expect(image.props.height).toBe(8.25);
+        expect(image.props.href).toBe(TEST_ICON);
+        expect(image.props.width).toBe(8.25);
+        expect(image.props.x).toBe(12.375);
+        expect(image.props.y).toBe(12.375);
+        expect(logoBackground.props.fill).toBe('#ffffff');
+        expect(logoBackground.props.height).toBe(11);
+        expect(logoBackground.props.width).toBe(11);
+        expect(logoBackground.props.x).toBe(11);
+        expect(logoBackground.props.y).toBe(11);
+        expect(svg.props.viewBox).toBe('0 0 33 33');
     });
 });
 

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -31,6 +31,7 @@ export * from './wallet-ui-list';
 export * from './wallet-ui-list-button';
 export * from './wallet-ui-modal';
 export * from './wallet-ui-modal-trigger';
+export * from './wallet-ui-qr-code';
 
 // Re-exports
 export * from '@solana/react';

--- a/packages/react/src/wallet-ui-qr-code.tsx
+++ b/packages/react/src/wallet-ui-qr-code.tsx
@@ -1,0 +1,114 @@
+import { createQrCode, type QrCodeErrorCorrection, type QrCodeLogoOptions } from '@wallet-ui/core';
+import React from 'react';
+
+import { BaseSvg, BaseSvgProps } from './base-svg';
+
+export interface WalletUiQrCodeProps extends Omit<BaseSvgProps, 'children' | 'viewBox'> {
+    backgroundColor?: string;
+    border?: number;
+    errorCorrection?: QrCodeErrorCorrection;
+    foregroundColor?: string;
+    logo?: QrCodeLogoOptions;
+    title?: string;
+    value: string;
+}
+
+const DEFAULT_QR_CODE_BACKGROUND_COLOR = '#fff';
+const DEFAULT_QR_CODE_FOREGROUND_COLOR = '#000';
+const DEFAULT_QR_CODE_LOGO_SIZE = 0.2;
+const LOGO_BACKGROUND_PADDING = 1;
+const MAX_QR_CODE_LOGO_SIZE = 0.25;
+
+export function WalletUiQrCode({
+    backgroundColor = DEFAULT_QR_CODE_BACKGROUND_COLOR,
+    border,
+    errorCorrection,
+    foregroundColor = DEFAULT_QR_CODE_FOREGROUND_COLOR,
+    logo,
+    title,
+    value,
+    ...props
+}: WalletUiQrCodeProps) {
+    const effectiveErrorCorrection = errorCorrection ?? (logo ? 'high' : undefined);
+    const hasAccessibleName = Boolean(title || props['aria-label'] || props['aria-labelledby']);
+    const titleId = React.useId();
+    const qrCode = React.useMemo(
+        () =>
+            createQrCode(value, {
+                border,
+                errorCorrection: effectiveErrorCorrection,
+            }),
+        [border, effectiveErrorCorrection, value],
+    );
+    const path = React.useMemo(() => createQrCodeSvgPath(qrCode.cells), [qrCode.cells]);
+
+    return (
+        <BaseSvg
+            aria-hidden={hasAccessibleName ? undefined : true}
+            aria-labelledby={props['aria-labelledby'] ?? (title ? titleId : undefined)}
+            data-wu="wallet-ui-qr-code"
+            role={hasAccessibleName ? 'img' : undefined}
+            shapeRendering="crispEdges"
+            viewBox={`0 0 ${qrCode.size} ${qrCode.size}`}
+            {...props}
+        >
+            {title ? <title id={titleId}>{title}</title> : null}
+            <rect fill={backgroundColor} height={qrCode.size} width={qrCode.size} x={0} y={0} />
+            <path d={path} fill={foregroundColor} />
+            {logo ? <WalletUiQrCodeLogo backgroundColor={backgroundColor} logo={logo} size={qrCode.size} /> : null}
+        </BaseSvg>
+    );
+}
+
+function WalletUiQrCodeLogo({
+    backgroundColor,
+    logo,
+    size,
+}: {
+    backgroundColor: string;
+    logo: QrCodeLogoOptions;
+    size: number;
+}) {
+    const logoSize = size * getQrCodeLogoSize(logo.size);
+    const logoPosition = (size - logoSize) / 2;
+    const logoBackgroundPosition = Math.max(0, Math.floor(logoPosition) - LOGO_BACKGROUND_PADDING);
+    const logoBackgroundEnd = Math.min(size, Math.ceil(logoPosition + logoSize) + LOGO_BACKGROUND_PADDING);
+    const logoBackgroundSize = logoBackgroundEnd - logoBackgroundPosition;
+    const logoBackgroundColor = logo.backgroundColor ?? backgroundColor;
+
+    return (
+        <>
+            <rect
+                fill={logoBackgroundColor}
+                height={formatSvgNumber(logoBackgroundSize)}
+                width={formatSvgNumber(logoBackgroundSize)}
+                x={formatSvgNumber(logoBackgroundPosition)}
+                y={formatSvgNumber(logoBackgroundPosition)}
+            />
+            <image
+                height={formatSvgNumber(logoSize)}
+                href={logo.href}
+                preserveAspectRatio="xMidYMid meet"
+                width={formatSvgNumber(logoSize)}
+                x={formatSvgNumber(logoPosition)}
+                y={formatSvgNumber(logoPosition)}
+            />
+        </>
+    );
+}
+
+function createQrCodeSvgPath(cells: boolean[][]): string {
+    return cells
+        .flatMap((row, rowIndex) =>
+            row.map((cell, columnIndex) => (cell ? `M${columnIndex} ${rowIndex}h1v1H${columnIndex}z` : '')),
+        )
+        .join('');
+}
+
+function formatSvgNumber(value: number): number {
+    return Number(value.toFixed(6));
+}
+
+function getQrCodeLogoSize(size = DEFAULT_QR_CODE_LOGO_SIZE): number {
+    return Math.min(size, MAX_QR_CODE_LOGO_SIZE);
+}


### PR DESCRIPTION
Add WalletUiQrCode for rendering QR codes from React, including optional centered logo support.

Add playground examples for plain QR codes plus wallet-ui and Solana logo overlays.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced `WalletUiQrCode` component for rendering customizable QR codes with configurable colors, borders, and error correction levels
  * Added support for optional centered logo overlays on QR codes
  * Component includes accessibility features and is now available in the main React package exports

<!-- end of auto-generated comment: release notes by coderabbit.ai -->