### PR TITLE
docs: add React island dropdown demo

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -1,6 +1,7 @@
 // @ts-check
 import catppuccin from '@catppuccin/starlight';
 import cloudflare from '@astrojs/cloudflare';
+import react from '@astrojs/react';
 import { defineConfig } from 'astro/config';
 import starlight from '@astrojs/starlight';
 import tailwindcss from '@tailwindcss/vite';
@@ -33,6 +34,7 @@ export default defineConfig({
         prerenderEnvironment: 'node',
     }),
     integrations: [
+        react(),
         starlight({
             title: siteName,
             description: siteDescription,
@@ -99,6 +101,9 @@ export default defineConfig({
                     light: { flavor: 'latte' },
                 }),
             ],
+            components: {
+                ThemeProvider: './src/components/starlight/ThemeProvider.astro',
+            },
             customCss: ['./src/styles/global.css'],
             routeMiddleware: './src/starlight-route-data.ts',
         }),

--- a/docs/package.json
+++ b/docs/package.json
@@ -5,7 +5,8 @@
     "type": "module",
     "scripts": {
         "astro": "astro",
-        "build": "astro build",
+        "build": "pnpm build:dependencies && astro build",
+        "build:dependencies": "pnpm --workspace-root turbo run compile:js compile:typedefs --filter=@wallet-ui/docs^...",
         "check": "astro check",
         "check:dead-links": "pnpm build && pnpm check:dead-links:dist",
         "check:dead-links:dist": "node scripts/check-dead-links.mjs",
@@ -18,11 +19,15 @@
     },
     "dependencies": {
         "@astrojs/cloudflare": "^13.1.6",
+        "@astrojs/react": "^5.0.7",
         "@astrojs/starlight": "^0.38.1",
         "@astrojs/starlight-tailwind": "^5.0.0",
         "@catppuccin/starlight": "^2.0.1",
         "@tailwindcss/vite": "^4.1.18",
+        "@wallet-ui/react": "workspace:*",
         "astro": "^6.1.5",
+        "react": "^19.2.1",
+        "react-dom": "^19.2.1",
         "sharp": "^0.34.2",
         "tailwindcss": "^4.1.18"
     },

--- a/docs/src/components/docs/WalletUiDropdownDemo.tsx
+++ b/docs/src/components/docs/WalletUiDropdownDemo.tsx
@@ -1,0 +1,32 @@
+import {
+    createSolanaDevnet,
+    createSolanaLocalnet,
+    createSolanaTestnet,
+    createWalletUiConfig,
+    WalletUi,
+    WalletUiClusterDropdown,
+    WalletUiDropdown,
+} from '@wallet-ui/react';
+
+const walletUiConfig = createWalletUiConfig({
+    clusters: [createSolanaDevnet(), createSolanaLocalnet(), createSolanaTestnet()],
+});
+
+export default function WalletUiDropdownDemo() {
+    return (
+        <div className="wallet-ui-react-island">
+            <WalletUi config={walletUiConfig}>
+                <div className="wallet-ui-react-island__controls">
+                    <div className="wallet-ui-react-island__control">
+                        <p className="wallet-ui-react-island__label">Cluster</p>
+                        <WalletUiClusterDropdown showIndicator />
+                    </div>
+                    <div className="wallet-ui-react-island__control">
+                        <p className="wallet-ui-react-island__label">Wallet</p>
+                        <WalletUiDropdown />
+                    </div>
+                </div>
+            </WalletUi>
+        </div>
+    );
+}

--- a/docs/src/components/starlight/ThemeProvider.astro
+++ b/docs/src/components/starlight/ThemeProvider.astro
@@ -1,0 +1,23 @@
+{/* This is intentionally inlined to avoid FOUC. */}
+<script is:inline>
+	window.StarlightThemeProvider = (() => {
+		const iconPaths = {
+			auto: '<path d="M21 14h-1V7a3 3 0 0 0-3-3H7a3 3 0 0 0-3 3v7H3a1 1 0 0 0-1 1v2a3 3 0 0 0 3 3h14a3 3 0 0 0 3-3v-2a1 1 0 0 0-1-1ZM6 7a1 1 0 0 1 1-1h10a1 1 0 0 1 1 1v7H6V7Zm14 10a1 1 0 0 1-1 1H5a1 1 0 0 1-1-1v-1h16v1Z"/>',
+			dark: '<path d="M21.64 13a1 1 0 0 0-1.05-.14 8.049 8.049 0 0 1-3.37.73 8.15 8.15 0 0 1-8.14-8.1 8.59 8.59 0 0 1 .25-2A1 1 0 0 0 8 2.36a10.14 10.14 0 1 0 14 11.69 1 1 0 0 0-.36-1.05Zm-9.5 6.69A8.14 8.14 0 0 1 7.08 5.22v.27a10.15 10.15 0 0 0 10.14 10.14 9.784 9.784 0 0 0 2.1-.22 8.11 8.11 0 0 1-7.18 4.32v-.04Z"/>',
+			light: '<path d="M5 12a1 1 0 0 0-1-1H3a1 1 0 0 0 0 2h1a1 1 0 0 0 1-1Zm.64 5-.71.71a1 1 0 0 0 0 1.41 1 1 0 0 0 1.41 0l.71-.71A1 1 0 0 0 5.64 17ZM12 5a1 1 0 0 0 1-1V3a1 1 0 0 0-2 0v1a1 1 0 0 0 1 1Zm5.66 2.34a1 1 0 0 0 .7-.29l.71-.71a1 1 0 1 0-1.41-1.41l-.66.71a1 1 0 0 0 0 1.41 1 1 0 0 0 .66.29Zm-12-.29a1 1 0 0 0 1.41 0 1 1 0 0 0 0-1.41l-.71-.71a1.004 1.004 0 1 0-1.43 1.41l.73.71ZM21 11h-1a1 1 0 0 0 0 2h1a1 1 0 0 0 0-2Zm-2.64 6A1 1 0 0 0 17 18.36l.71.71a1 1 0 0 0 1.41 0 1 1 0 0 0 0-1.41l-.76-.66ZM12 6.5a5.5 5.5 0 1 0 5.5 5.5A5.51 5.51 0 0 0 12 6.5Zm0 9a3.5 3.5 0 1 1 0-7 3.5 3.5 0 0 1 0 7Zm0 3.5a1 1 0 0 0-1 1v1a1 1 0 0 0 2 0v-1a1 1 0 0 0-1-1Z"/>',
+		};
+		const storedTheme = typeof localStorage !== 'undefined' && localStorage.getItem('starlight-theme');
+		const theme = storedTheme || (window.matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark');
+		document.documentElement.dataset.theme = theme === 'light' ? 'light' : 'dark';
+		return {
+			updatePickers(theme = storedTheme || 'auto') {
+				document.querySelectorAll('starlight-theme-select').forEach((picker) => {
+					const select = picker.querySelector('select');
+					if (select) select.value = theme;
+					const oldIcon = picker.querySelector('svg.label-icon');
+					if (oldIcon && iconPaths[theme]) oldIcon.innerHTML = iconPaths[theme];
+				});
+			},
+		};
+	})();
+</script>

--- a/docs/src/content/docs/react/components/dropdown.mdx
+++ b/docs/src/content/docs/react/components/dropdown.mdx
@@ -3,6 +3,8 @@ title: Dropdown
 description: A dropdown that lists wallets, allows to connect and disconnect
 ---
 
+import WalletUiDropdownDemo from '../../../../components/docs/WalletUiDropdownDemo';
+
 The `WalletUiDropdown` is a complete, pre-built component that renders a button for wallet selection. When clicked, it displays a list of detected wallets, allowing users to connect and disconnect.
 
 When a user is connected, the button will display their truncated address.
@@ -19,4 +21,4 @@ function MyComponent() {
 
 ## Example
 
-Live interactive examples are omitted from this static docs site.
+<WalletUiDropdownDemo client:only="react" />

--- a/docs/src/styles/global.css
+++ b/docs/src/styles/global.css
@@ -15,3 +15,82 @@
 Add additional Tailwind styles to this file:
 https://tailwindcss.com/docs/adding-custom-styles#using-custom-css
 */
+
+.wallet-ui-react-island {
+    border: 1px solid var(--sl-color-gray-5);
+    border-radius: 0.5rem;
+    margin-top: 1rem;
+    padding: 1rem;
+}
+
+.wallet-ui-react-island__controls {
+    display: grid;
+    gap: 0.75rem;
+    grid-template-columns: repeat(auto-fit, minmax(12rem, 1fr));
+}
+
+.wallet-ui-react-island__control {
+    margin-top: 0;
+    min-width: 0;
+}
+
+.wallet-ui-react-island__label {
+    color: var(--sl-color-gray-2);
+    font-size: 0.875rem;
+    font-weight: 600;
+    line-height: 1.25rem;
+    margin: 0 0 0.375rem;
+}
+
+.wallet-ui-react-island [data-wu='base-button'] {
+    align-items: center;
+    background: var(--sl-color-bg-nav);
+    border: 1px solid var(--sl-color-gray-5);
+    border-radius: 0.375rem;
+    color: var(--sl-color-white);
+    display: inline-flex;
+    gap: 0.5rem;
+    justify-content: space-between;
+    min-height: 2.5rem;
+    padding: 0.5rem 0.75rem;
+    width: 100%;
+}
+
+.wallet-ui-react-island [data-wu='base-button']:hover {
+    border-color: var(--sl-color-accent);
+}
+
+.wallet-ui-react-island [data-wu='base-dropdown'] {
+    position: relative;
+}
+
+.wallet-ui-react-island [data-wu='base-dropdown-list'] {
+    background: var(--sl-color-black);
+    border: 1px solid var(--sl-color-gray-5);
+    border-radius: 0.375rem;
+    box-shadow: var(--sl-shadow-md);
+    display: grid;
+    gap: 0.25rem;
+    margin-top: 0.375rem;
+    min-width: 100%;
+    padding: 0.375rem;
+    z-index: 10;
+}
+
+.wallet-ui-react-island [data-wu='base-dropdown-list'][hidden] {
+    display: none;
+}
+
+.wallet-ui-react-island [data-wu='base-dropdown-item'] {
+    background: transparent;
+    border: 0;
+    border-radius: 0.25rem;
+    color: var(--sl-color-white);
+    padding: 0.5rem 0.625rem;
+    text-align: left;
+    width: 100%;
+}
+
+.wallet-ui-react-island [data-wu='base-dropdown-item']:hover {
+    background: var(--sl-color-gray-6);
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -88,6 +88,9 @@ importers:
       '@astrojs/cloudflare':
         specifier: ^13.1.6
         version: 13.1.7(@types/node@25.3.1)(astro@6.1.5(@types/node@25.3.1)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.60.1)(terser@5.46.1)(typescript@6.0.3)(yaml@2.8.3))(bufferutil@4.0.9)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(utf-8-validate@5.0.10)(workerd@1.20260405.1)(wrangler@4.81.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(yaml@2.8.3)
+      '@astrojs/react':
+        specifier: ^5.0.7
+        version: 5.0.7(@types/node@25.3.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(jiti@2.6.1)(lightningcss@1.32.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(terser@5.46.1)(yaml@2.8.3)
       '@astrojs/starlight':
         specifier: ^0.38.1
         version: 0.38.3(astro@6.1.5(@types/node@25.3.1)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.60.1)(terser@5.46.1)(typescript@6.0.3)(yaml@2.8.3))
@@ -100,9 +103,18 @@ importers:
       '@tailwindcss/vite':
         specifier: ^4.1.18
         version: 4.2.2(vite@7.3.2(@types/node@25.3.1)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.8.3))
+      '@wallet-ui/react':
+        specifier: workspace:*
+        version: link:../packages/react
       astro:
         specifier: ^6.1.5
         version: 6.1.5(@types/node@25.3.1)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.60.1)(terser@5.46.1)(typescript@6.0.3)(yaml@2.8.3)
+      react:
+        specifier: ^19.2.1
+        version: 19.2.1
+      react-dom:
+        specifier: ^19.2.1
+        version: 19.2.1(react@19.2.1)
       sharp:
         specifier: ^0.34.2
         version: 0.34.5
@@ -933,6 +945,9 @@ packages:
   '@astrojs/compiler@3.0.1':
     resolution: {integrity: sha512-z97oYbdebO5aoWzuJ/8q5hLK232+17KcLZ7cJ8BCWk6+qNzVxn/gftC0KzMBUTD8WAaBkPpNSQK6PXLnNrZ0CA==}
 
+  '@astrojs/internal-helpers@0.10.0':
+    resolution: {integrity: sha512-Ry2R3VPeIN4uPCSA4xQc+e+vsJXkalKpEbDc07hV+a/o5Bs2N/s/uDcPJH/05L19DKh9tAy7e6JM3YZ6Cxfezw==}
+
   '@astrojs/internal-helpers@0.8.0':
     resolution: {integrity: sha512-J56GrhEiV+4dmrGLPNOl2pZjpHXAndWVyiVDYGDuw6MWKpBSEMLdFxHzeM/6sqaknw9M+HFfHZAcvi3OfT3D/w==}
 
@@ -960,6 +975,15 @@ packages:
   '@astrojs/prism@4.0.1':
     resolution: {integrity: sha512-nksZQVjlferuWzhPsBpQ1JE5XuKAf1id1/9Hj4a9KG4+ofrlzxUUwX4YGQF/SuDiuiGKEnzopGOt38F3AnVWsQ==}
     engines: {node: '>=22.12.0'}
+
+  '@astrojs/react@5.0.7':
+    resolution: {integrity: sha512-N9cCoxvnLWaP+AK1Fv4e5Mc7ktnVTpSo2nWLwvD9Ohr1dJKygwrTSm9yatqoahgb1A5Kwjg/rT2shRiIVdn3aw==}
+    engines: {node: '>=22.12.0'}
+    peerDependencies:
+      '@types/react': ^17.0.50 || ^18.0.21 || ^19.0.0
+      '@types/react-dom': ^17.0.17 || ^18.0.6 || ^19.0.0
+      react: ^17.0.2 || ^18.0.0 || ^19.0.0
+      react-dom: ^17.0.2 || ^18.0.0 || ^19.0.0
 
   '@astrojs/sitemap@3.7.2':
     resolution: {integrity: sha512-PqkzkcZTb5ICiyIR8VoKbIAP/laNRXi5tw616N1Ckk+40oNB8Can1AzVV56lrbC5GKSZFCyJYUVYqVivMisvpA==}
@@ -4189,6 +4213,9 @@ packages:
   '@rolldown/pluginutils@1.0.0-beta.47':
     resolution: {integrity: sha512-8QagwMH3kNCuzD8EWL8R2YPW5e4OrHNSAHRFDdmFqEwEaD/KcNKjVoumo+gP2vW5eKB2UPbM6vTYiGZX0ixLnw==}
 
+  '@rolldown/pluginutils@1.0.0-rc.3':
+    resolution: {integrity: sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q==}
+
   '@rollup/plugin-virtual@3.0.2':
     resolution: {integrity: sha512-10monEYsBp3scM4/ND4LNH5Rxvh3e/cVeL3jWTgZ2SrQ+BmUoQcopVQvnaMcOnykb1VkxUFuDAN+0FnpTFRy2A==}
     engines: {node: '>=14.0.0'}
@@ -5536,6 +5563,12 @@ packages:
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
 
+  '@vitejs/plugin-react@5.2.0':
+    resolution: {integrity: sha512-YmKkfhOAi3wsB1PhJq5Scj3GXMn3WvtQ/JC0xoopuHoXSdmtdStOpFrYaT1kie2YgFBcIe64ROzMYRjCrYOdYw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    peerDependencies:
+      vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
+
   '@vitest/coverage-v8@4.1.7':
     resolution: {integrity: sha512-qsYPeXc5Q9dFLd1i8Ap+Bx8sQgcp+rFVQo4R0dDsWNBzl26ldVF1qOO+RL24K7FDrR6pA+50XedRLSoSG24bVQ==}
     peerDependencies:
@@ -6562,6 +6595,9 @@ packages:
 
   devalue@5.7.1:
     resolution: {integrity: sha512-MUbZ586EgQqdRnC4yDrlod3BEdyvE4TapGYHMW2CiaW+KkkFmWEFqBUaLltEZCGi0iFXCEjRF0OjF0DV2QHjOA==}
+
+  devalue@5.8.1:
+    resolution: {integrity: sha512-4CXDYRBGqN+57wVJkuXBYmpAVUSg3L6JAQa/DFqm238G73E1wuyc/JhGQJzN7vUf/CMphYau2zXbfWzDR5aTEw==}
 
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
@@ -10796,6 +10832,17 @@ snapshots:
 
   '@astrojs/compiler@3.0.1': {}
 
+  '@astrojs/internal-helpers@0.10.0':
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      js-yaml: 4.1.1
+      picomatch: 4.0.4
+      retext-smartypants: 6.2.0
+      shiki: 4.0.2
+      smol-toml: 1.6.1
+      unified: 11.0.5
+
   '@astrojs/internal-helpers@0.8.0':
     dependencies:
       picomatch: 4.0.4
@@ -10873,6 +10920,31 @@ snapshots:
   '@astrojs/prism@4.0.1':
     dependencies:
       prismjs: 1.30.0
+
+  '@astrojs/react@5.0.7(@types/node@25.3.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(jiti@2.6.1)(lightningcss@1.32.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(terser@5.46.1)(yaml@2.8.3)':
+    dependencies:
+      '@astrojs/internal-helpers': 0.10.0
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+      '@vitejs/plugin-react': 5.2.0(vite@7.3.2(@types/node@25.3.1)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.8.3))
+      devalue: 5.8.1
+      react: 19.2.1
+      react-dom: 19.2.1(react@19.2.1)
+      ultrahtml: 1.6.0
+      vite: 7.3.2(@types/node@25.3.1)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.8.3)
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
 
   '@astrojs/sitemap@3.7.2':
     dependencies:
@@ -14726,6 +14798,8 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.0-beta.47': {}
 
+  '@rolldown/pluginutils@1.0.0-rc.3': {}
+
   '@rollup/plugin-virtual@3.0.2(rollup@4.52.1)':
     optionalDependencies:
       rollup: 4.52.1
@@ -16551,6 +16625,18 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@vitejs/plugin-react@5.2.0(vite@7.3.2(@types/node@25.3.1)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.8.3))':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/plugin-transform-react-jsx-self': 7.29.7(@babel/core@7.29.0)
+      '@babel/plugin-transform-react-jsx-source': 7.29.7(@babel/core@7.29.0)
+      '@rolldown/pluginutils': 1.0.0-rc.3
+      '@types/babel__core': 7.20.5
+      react-refresh: 0.18.0
+      vite: 7.3.2(@types/node@25.3.1)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.8.3)
+    transitivePeerDependencies:
+      - supports-color
+
   '@vitest/coverage-v8@4.1.7(vitest@4.1.7)':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
@@ -17814,6 +17900,8 @@ snapshots:
   detect-node-es@1.1.0: {}
 
   devalue@5.7.1: {}
+
+  devalue@5.8.1: {}
 
   devlop@1.1.0:
     dependencies:


### PR DESCRIPTION
Enable Astro React integration for the docs site and add the private docs dependencies needed to hydrate React components.

Render the dropdown docs example through a Wallet UI React island, add scoped demo styles, and keep Starlight dev styles active without the theme icon template.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Interactive demo component for Wallet UI dropdown showing cluster and wallet selection controls
  * Theme provider with localStorage persistence and system preference detection

* **Documentation**
  * Dropdown component documentation now includes embedded interactive examples
  * Added comprehensive styling for wallet UI components and controls

<!-- end of auto-generated comment: release notes by coderabbit.ai -->