### PR TITLE
ci: format Changesets version PRs

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -60,6 +60,7 @@ jobs:
           commit: 'chore: update versions'
           publish: pnpm changeset:publish
           title: 'chore: update versions'
+          version: pnpm changeset:version
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PUBLISH_TAG: latest

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "scripts": {
         "build": "pnpm lint && pnpm format:check && turbo run --concurrency=${TURBO_CONCURRENCY:-95.84%} build",
         "changeset:publish": "turbo publish-packages --concurrency=${TURBO_CONCURRENCY:-95.84%} && echo 'published=true' >> $GITHUB_OUTPUT",
+        "changeset:version": "changeset version && pnpm format",
         "clean": "find . -type d \\( -name 'node_modules' -o -name 'android' -o -name 'build' -o -name 'dist' -o -name '.turbo' -o -name '.wxt' -o -name '.expo' -o -name '.astro' -o -name '.wrangler' \\) -prune -exec rm -rf '{}' +",
         "compile": "turbo run --concurrency=${TURBO_CONCURRENCY:-95.84%} compile:js compile:typedefs",
         "format": "oxfmt",


### PR DESCRIPTION
Run Changesets versioning through a repo script that formats the generated files before the release PR commit is created.

This keeps generated changelogs compatible with the root build's oxfmt check.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced package versioning workflow to automate version computation and formatting during changesets operations, improving release process reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->