### PR TITLE
feat(react-native): preserve custom client types

### DIFF
--- a/.changeset/generic-react-native-client.md
+++ b/.changeset/generic-react-native-client.md
@@ -1,0 +1,5 @@
+---
+'@wallet-ui/react-native-kit': minor
+---
+
+Preserve custom client capabilities through `MobileWalletProvider` and `useMobileWallet`.

--- a/packages/react-native-kit/src/__tests__/mobile-wallet-provider-test.tsx
+++ b/packages/react-native-kit/src/__tests__/mobile-wallet-provider-test.tsx
@@ -4,6 +4,7 @@ import React, { type ReactNode, useContext } from 'react';
 import { createAsyncStorageCache } from '../async-storage-cache';
 import type { Cache } from '../cache';
 import type { Client } from '../client';
+import { createDefaultClient } from '../create-default-client';
 import { MobileWalletProvider, MobileWalletProviderContext } from '../mobile-wallet-provider';
 import { createCache } from '../test-utils/fixtures';
 import { act, renderHook } from '../test-utils/react-test-renderer';
@@ -12,8 +13,12 @@ import type { WalletAuthorization } from '../use-authorization';
 vi.mock('../async-storage-cache', () => ({
     createAsyncStorageCache: vi.fn(),
 }));
+vi.mock('../create-default-client', () => ({
+    createDefaultClient: vi.fn(),
+}));
 
 const mockCreateAsyncStorageCache = vi.mocked(createAsyncStorageCache);
+const mockCreateDefaultClient = vi.mocked(createDefaultClient);
 const CLUSTER = {
     id: 'solana:devnet',
     url: 'https://rpc.wallet-ui.dev',
@@ -27,6 +32,18 @@ const IDENTITY = {
 describe('MobileWalletProvider', () => {
     beforeEach(() => {
         mockCreateAsyncStorageCache.mockReset();
+        mockCreateDefaultClient.mockReset();
+    });
+
+    it('requires a client factory for explicit custom client types', () => {
+        expectTypeOf<Parameters<typeof MobileWalletProvider<CustomClient>>[0]>().toMatchTypeOf<{
+            createClient: (cluster: { url: string; urlWs?: string }) => CustomClient;
+        }>();
+        expectTypeOf<{
+            children: ReactNode;
+            cluster: typeof CLUSTER;
+            identity: AppIdentity;
+        }>().toMatchTypeOf<React.ComponentProps<typeof MobileWalletProvider>>();
     });
 
     it('uses the provided cache and client factory and fetches authorization on mount', async () => {
@@ -84,7 +101,31 @@ describe('MobileWalletProvider', () => {
         expect(hook.result.client).toBe(client);
         expect(hook.result.identity).toBe(IDENTITY);
     });
+
+    it('creates a default client when a client factory is not provided', async () => {
+        expect.assertions(2);
+        const cache = createCache();
+        const client = createClient();
+
+        mockCreateDefaultClient.mockReturnValue(client);
+
+        const hook = renderHook(useProviderState, {
+            initialProps: undefined,
+            wrapper: createProviderWrapper({ cache }),
+        });
+
+        await act(async () => {
+            await Promise.resolve();
+        });
+
+        expect(mockCreateDefaultClient).toHaveBeenCalledWith(CLUSTER);
+        expect(hook.result.client).toBe(client);
+    });
 });
+
+type CustomClient = Client & {
+    extraMethod: () => string;
+};
 
 function createClient(): Client {
     return {

--- a/packages/react-native-kit/src/__tests__/use-mobile-wallet-test.tsx
+++ b/packages/react-native-kit/src/__tests__/use-mobile-wallet-test.tsx
@@ -3,6 +3,7 @@ import type { Mock } from 'vitest';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 
 import { resetAsyncStorageMock } from '../../../test-config/react-native-unit-test-utils';
+import type { BaseClient, Client } from '../client';
 import { createExpectedAccount, FIRST_ADDRESS, FIRST_ADDRESS_BASE64 } from '../test-utils/fixtures';
 import { useMobileWallet } from '../use-mobile-wallet';
 
@@ -90,6 +91,24 @@ describe('useMobileWallet', () => {
         expect(callback).toHaveBeenCalledWith(transportWallet);
         expect(mockAuthorizeSession).not.toHaveBeenCalled();
         expect(result).toBe('connected-via-callback');
+    });
+
+    it('preserves a custom client type', () => {
+        expect.assertions(1);
+        const createClient = () => ({
+            extraMethod: vi.fn(() => 'extra capability'),
+            rpc: {} as BaseClient['rpc'],
+            rpcSubscriptions: {} as BaseClient['rpcSubscriptions'],
+        });
+        const client = createClient();
+        const { mobileWallet } = useMobileWalletTestHarness<ReturnType<typeof createClient>>({
+            contextOverrides: { client },
+        });
+        const { mobileWallet: defaultMobileWallet } = useMobileWalletTestHarness();
+
+        expectTypeOf(defaultMobileWallet.client.rpc.getBalance).toBeFunction();
+        expectTypeOf<ReturnType<typeof mobileWallet.client.extraMethod>>().toEqualTypeOf<string>();
+        expect(mobileWallet.client.extraMethod()).toBe('extra capability');
     });
 
     it('rejects invalid identity URI schemes before launching the wallet transport', async () => {
@@ -342,7 +361,7 @@ function createTransportWallet({
     };
 }
 
-function useMobileWalletTestHarness({
+function useMobileWalletTestHarness<TClient extends BaseClient = Client>({
     contextOverrides,
     transportWallet = createTransportWallet(),
 }: {
@@ -381,7 +400,7 @@ function useMobileWalletTestHarness({
     mockUseAuthorization.mockReturnValue(createAuthorizationHookValue());
 
     return {
-        mobileWallet: useMobileWallet(),
+        mobileWallet: useMobileWallet<TClient>(),
         transportWallet,
     };
 }

--- a/packages/react-native-kit/src/client.tsx
+++ b/packages/react-native-kit/src/client.tsx
@@ -1,6 +1,8 @@
-import { createSolanaRpc, createSolanaRpcSubscriptions } from '@solana/kit';
+import type { Rpc, RpcSubscriptions, SolanaRpcApi, SolanaRpcSubscriptionsApi } from '@solana/kit';
 
-export interface Client {
-    rpc: ReturnType<typeof createSolanaRpc>;
-    rpcSubscriptions: ReturnType<typeof createSolanaRpcSubscriptions>;
+export interface BaseClient {
+    rpc: Rpc<SolanaRpcApi>;
+    rpcSubscriptions: RpcSubscriptions<SolanaRpcSubscriptionsApi>;
 }
+
+export interface Client extends BaseClient {}

--- a/packages/react-native-kit/src/index.ts
+++ b/packages/react-native-kit/src/index.ts
@@ -10,5 +10,5 @@ export * from '@solana-mobile/mobile-wallet-adapter-protocol-kit';
 export * from '@wallet-ui/core';
 export { toUint8Array, fromUint8Array } from 'js-base64';
 export { createDefaultClient } from './create-default-client';
-export type { Client } from './client';
+export type { BaseClient, Client } from './client';
 export { convertSignInResult } from './convert-sign-in-result';

--- a/packages/react-native-kit/src/mobile-wallet-provider.tsx
+++ b/packages/react-native-kit/src/mobile-wallet-provider.tsx
@@ -4,32 +4,41 @@ import React, { createContext, type ReactNode, useEffect, useMemo, useState } fr
 
 import { createAsyncStorageCache } from './async-storage-cache';
 import { AuthorizationStore, createAuthorizationStore } from './authorization-store';
-import { Client } from './client';
+import type { BaseClient, Client } from './client';
 import { createDefaultClient } from './create-default-client';
 import { WalletAuthorization, WalletAuthorizationCache, WalletAuthorizationProps } from './use-authorization';
 
-export interface MobileWalletProviderProps {
-    cache?: WalletAuthorizationCache;
-    children: ReactNode;
-    cluster: Pick<SolanaCluster, 'id' | 'url' | 'urlWs'>;
-    createClient?: (cluster: { url: string; urlWs?: string }) => Client;
-    identity: AppIdentity;
-}
-export interface MobileWalletProviderState extends WalletAuthorizationProps {
-    client: Client;
+type ClientFactory<TClient extends BaseClient> = (cluster: { url: string; urlWs?: string }) => TClient;
+type MobileWalletProviderClientProps<TClient extends BaseClient> = Client extends TClient
+    ? { createClient?: ClientFactory<TClient> }
+    : { createClient: ClientFactory<TClient> };
+export type MobileWalletProviderProps<TClient extends BaseClient = Client> =
+    MobileWalletProviderClientProps<TClient> & {
+        cache?: WalletAuthorizationCache;
+        children: ReactNode;
+        cluster: Pick<SolanaCluster, 'id' | 'url' | 'urlWs'>;
+        identity: AppIdentity;
+    };
+export interface MobileWalletProviderState<TClient extends BaseClient = Client> extends WalletAuthorizationProps {
+    client: TClient;
     store: AuthorizationStore;
 }
 
-export const MobileWalletProviderContext = createContext<MobileWalletProviderState>({} as MobileWalletProviderState);
-export function MobileWalletProvider({
+export const MobileWalletProviderContext = createContext<MobileWalletProviderState<BaseClient>>(
+    {} as MobileWalletProviderState<BaseClient>,
+);
+export function MobileWalletProvider<TClient extends BaseClient = Client>({
     cache: userCache,
     children,
     cluster,
-    createClient = createDefaultClient,
+    createClient,
     identity,
-}: MobileWalletProviderProps) {
+}: MobileWalletProviderProps<TClient>) {
     const cache = useMemo(() => userCache ?? createAsyncStorageCache<WalletAuthorization>(), [userCache]);
-    const client = useMemo(() => createClient(cluster), [createClient, cluster]);
+    const client = useMemo(
+        () => (createClient ? createClient(cluster) : createDefaultClient(cluster)),
+        [createClient, cluster],
+    );
 
     const [store] = useState(() => createAuthorizationStore({ cache }));
 

--- a/packages/react-native-kit/src/use-mobile-wallet.ts
+++ b/packages/react-native-kit/src/use-mobile-wallet.ts
@@ -16,14 +16,15 @@ import { transact } from '@solana-mobile/mobile-wallet-adapter-protocol-kit';
 import { useCallback, useContext, useMemo } from 'react';
 
 import { assertValidIdentityUri } from './assert-valid-identity-uri';
+import type { BaseClient, Client } from './client';
 import { SignInOutput } from './convert-sign-in-result';
-import { MobileWalletProviderContext } from './mobile-wallet-provider';
+import { MobileWalletProviderContext, type MobileWalletProviderState } from './mobile-wallet-provider';
 import { TransactionSignatures } from './types';
 import { Account, useAuthorization } from './use-authorization';
 
 const decoder = getBase58Decoder();
-export function useMobileWallet() {
-    const ctx = useContext(MobileWalletProviderContext);
+export function useMobileWallet<TClient extends BaseClient = Client>() {
+    const ctx = useContext(MobileWalletProviderContext) as MobileWalletProviderState<TClient>;
     const {
         authorizeSessionWithSignIn,
         authorizeSession,


### PR DESCRIPTION
Add a structural BaseClient constraint and thread custom client types through the mobile wallet provider and hook.

Keep the default Client API intact and cover richer client factories with type assertions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for preserving custom client capabilities when using `MobileWalletProvider` and `useMobileWallet`.
  * Exported a reusable base client type for custom client integrations.
  * Existing client behavior remains available by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->