### PR TITLE
feat(react-native): add mobile wallet client plugin

### DIFF
--- a/.changeset/mobile-wallet-kit-plugin.md
+++ b/.changeset/mobile-wallet-kit-plugin.md
@@ -1,0 +1,5 @@
+---
+'@wallet-ui/react-native-kit': minor
+---
+
+Add a Kit 7 `mobileWallet` plugin with a lazy MWA payer, headless session lifecycle, and wallet-routed transaction plan execution.

--- a/packages/react-native-kit/README.md
+++ b/packages/react-native-kit/README.md
@@ -7,7 +7,125 @@
 
 # @wallet-ui/react-native-kit
 
-This package provides the official React Native components and hooks for [Wallet UI](https://wallet-ui.dev), a modern,
-headless UI component library for Solana apps.
+This package provides Wallet UI's React Native hooks and Mobile Wallet Adapter integration for Solana apps.
 
-# TBD
+## Mobile Wallet Adapter Kit plugin
+
+`mobileWallet()` adds three capabilities to a Kit 7 client:
+
+- A lazy `payer` backed by the currently selected Mobile Wallet Adapter account.
+- A `transactionPlanExecutor` that submits through the wallet's `signAndSendTransactions` method.
+- Headless `client.wallet.connect()` and `client.wallet.disconnect()` actions.
+
+Install the Kit plugins used to build the client:
+
+```sh
+pnpm add @solana/kit@^7 @solana/kit-plugin-instruction-plan @solana/kit-plugin-rpc @wallet-ui/react-native-kit
+```
+
+Compose the granular plugins in capability order:
+
+```ts
+import { createClient } from '@solana/kit';
+import { planAndSendTransactions } from '@solana/kit-plugin-instruction-plan';
+import { rpcTransactionPlanner, solanaRpcConnection } from '@solana/kit-plugin-rpc';
+import { mobileWallet, type MobileWalletConfig } from '@wallet-ui/react-native-kit';
+
+function createMobileClient(cluster: { url: string; urlWs?: string }, mobileWalletConfig: MobileWalletConfig) {
+    return createClient()
+        .use(
+            solanaRpcConnection({
+                rpcSubscriptionsUrl: cluster.urlWs,
+                rpcUrl: cluster.url,
+            }),
+        )
+        .use(mobileWallet(mobileWalletConfig))
+        .use(rpcTransactionPlanner({ estimateResourceLimits: false }))
+        .use(planAndSendTransactions());
+}
+
+export type MobileClient = ReturnType<typeof createMobileClient>;
+```
+
+The order reflects each plugin's required capabilities. `solanaRpcConnection()` provides RPC, `mobileWallet()` adds the payer and MWA executor, `rpcTransactionPlanner()` consumes the payer, and `planAndSendTransactions()` consumes the planner and executor.
+
+Use the granular RPC plugins instead of `solanaRpc()`. The preset installs an RPC transaction executor, which would replace the MWA executor and submit transactions through RPC.
+
+### React provider
+
+`MobileWalletProvider` passes its authorization store, chain, and identity to the client factory as the second argument:
+
+```tsx
+import type { Instruction } from '@solana/kit';
+import { MobileWalletProvider, useMobileWallet } from '@wallet-ui/react-native-kit';
+import type { ReactNode } from 'react';
+import { Button } from 'react-native';
+
+const cluster = {
+    id: 'solana:devnet',
+    url: 'https://api.devnet.solana.com',
+} as const;
+const identity = {
+    name: 'My app',
+    uri: 'https://example.com',
+};
+
+export function Providers({ children }: { children: ReactNode }) {
+    return (
+        <MobileWalletProvider<MobileClient> cluster={cluster} createClient={createMobileClient} identity={identity}>
+            {children}
+        </MobileWalletProvider>
+    );
+}
+
+export function SendButton({ instruction }: { instruction: Instruction }) {
+    const { client, connect } = useMobileWallet<MobileClient>();
+
+    return (
+        <Button
+            onPress={async () => {
+                await connect();
+                await client.sendTransaction([instruction]);
+            }}
+            title="Send"
+        />
+    );
+}
+```
+
+### Headless client
+
+The same plugin works without React. Create and hydrate an authorization store, connect, then use the standard Kit send methods:
+
+```ts
+import { type Cache, createAuthorizationStore, type WalletAuthorization } from '@wallet-ui/react-native-kit';
+
+// Any `Cache` implementation works. Back it with persistent storage so sessions survive app restarts.
+let cached: WalletAuthorization | undefined;
+const cache: Cache<WalletAuthorization | undefined> = {
+    async clear() {
+        cached = undefined;
+    },
+    async get() {
+        return cached;
+    },
+    async set(value) {
+        cached = value;
+    },
+};
+
+const store = createAuthorizationStore({ cache });
+await store.fetch();
+
+const client = createMobileClient(cluster, {
+    chain: cluster.id,
+    identity,
+    store,
+});
+
+await client.wallet.connect();
+await client.sendTransaction([instruction]);
+await client.wallet.disconnect();
+```
+
+Reading `client.payer` before a session is authorized throws an error that directs the caller to connect first. The payer tracks the authorization store's selected account, so account changes do not require rebuilding the client. Repeated reads return the same signer reference until the selected account changes, which keeps `subscribeToPayer` and `payer` usable together as a `useSyncExternalStore` subscription.

--- a/packages/react-native-kit/package.json
+++ b/packages/react-native-kit/package.json
@@ -75,9 +75,9 @@
         "@react-native-async-storage/async-storage": "^2.2.0",
         "@solana-mobile/mobile-wallet-adapter-protocol": "^2.2.8",
         "@solana-mobile/mobile-wallet-adapter-protocol-kit": "^0.3.1",
-        "@solana-program/memo": "^0.11.0",
-        "@solana/kit": "^6.1.0 || ^7.0.0",
-        "@solana/react": "^6.1.0",
+        "@solana-program/memo": "^0.12.0",
+        "@solana/kit": "^7.0.0",
+        "@solana/react": "^7.0.0",
         "@solana/wallet-standard-features": "1.3.0",
         "@wallet-standard/core": "1.1.1",
         "@wallet-standard/react": "1.0.1",
@@ -86,6 +86,8 @@
         "nanostores": "^1.2.0"
     },
     "devDependencies": {
+        "@solana/kit-plugin-instruction-plan": "^0.13.0",
+        "@solana/kit-plugin-rpc": "^0.16.0",
         "@types/react": "^19.1.17",
         "@types/react-dom": "^19.1.11",
         "@types/react-test-renderer": "^19.1.0",

--- a/packages/react-native-kit/src/__tests__/index-test.ts
+++ b/packages/react-native-kit/src/__tests__/index-test.ts
@@ -1,6 +1,7 @@
 import { createAuthorizationStore } from '../authorization-store';
 import { convertSignInResult } from '../convert-sign-in-result';
 import * as reactNativeKit from '../index';
+import { mobileWallet } from '../mobile-wallet';
 import { MobileWalletProvider, MobileWalletProviderContext } from '../mobile-wallet-provider';
 import { useAuthorization } from '../use-authorization';
 import { useMobileWallet } from '../use-mobile-wallet';
@@ -16,12 +17,13 @@ vi.mock('@react-native-async-storage/async-storage', () => ({
 
 describe('index', () => {
     it('re-exports the local runtime surface from the barrel', () => {
-        expect.assertions(6);
+        expect.assertions(7);
 
         expect(reactNativeKit.MobileWalletProvider).toBe(MobileWalletProvider);
         expect(reactNativeKit.MobileWalletProviderContext).toBe(MobileWalletProviderContext);
         expect(reactNativeKit.convertSignInResult).toBe(convertSignInResult);
         expect(reactNativeKit.createAuthorizationStore).toBe(createAuthorizationStore);
+        expect(reactNativeKit.mobileWallet).toBe(mobileWallet);
         expect(reactNativeKit.useAuthorization).toBe(useAuthorization);
         expect(reactNativeKit.useMobileWallet).toBe(useMobileWallet);
     });

--- a/packages/react-native-kit/src/__tests__/mobile-wallet-integration-test.ts
+++ b/packages/react-native-kit/src/__tests__/mobile-wallet-integration-test.ts
@@ -1,0 +1,93 @@
+import type { AppIdentity } from '@solana-mobile/mobile-wallet-adapter-protocol';
+import { getAddMemoInstruction } from '@solana-program/memo';
+import { createClient, getBase58Decoder } from '@solana/kit';
+import { planAndSendTransactions } from '@solana/kit-plugin-instruction-plan';
+import { rpcTransactionPlanner, solanaRpcConnection } from '@solana/kit-plugin-rpc';
+
+import { createAuthorizationStore } from '../authorization-store';
+import { mobileWallet } from '../mobile-wallet';
+import {
+    createAuthorizationResult,
+    createCache,
+    createExpectedAuthorization,
+    FIRST_ADDRESS,
+} from '../test-utils/fixtures';
+
+const mockTransact = vi.fn();
+
+vi.mock('@solana-mobile/mobile-wallet-adapter-protocol-kit', () => ({
+    transact: (...args: unknown[]) => mockTransact(...args),
+}));
+
+const BLOCKHASH = '11111111111111111111111111111111';
+const CHAIN = 'solana:devnet';
+const IDENTITY = {
+    name: 'Wallet UI',
+    uri: 'https://wallet-ui.dev',
+} as AppIdentity;
+const SIGNATURE_BYTES = new Uint8Array(64);
+
+describe('mobileWallet integration', () => {
+    beforeEach(() => {
+        mockTransact.mockReset();
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
+    it('plans with the real Kit plugins and submits the compiled transaction through MWA', async () => {
+        expect.assertions(8);
+        const store = createAuthorizationStore({ cache: createCache() });
+        const signAndSendTransactions = vi.fn().mockResolvedValue([SIGNATURE_BYTES]);
+        const wallet = {
+            authorize: vi.fn().mockResolvedValue(createAuthorizationResult()),
+            signAndSendTransactions,
+        };
+        mockTransact.mockImplementation(async callback => await callback(wallet));
+        const rpcResponse = {
+            id: '1',
+            jsonrpc: '2.0',
+            result: {
+                context: { slot: 42 },
+                value: { blockhash: BLOCKHASH, lastValidBlockHeight: 123 },
+            },
+        };
+        const fetch = vi.fn().mockResolvedValue({
+            json: async () => rpcResponse,
+            ok: true,
+            text: async () => JSON.stringify(rpcResponse),
+        });
+        vi.stubGlobal('fetch', fetch);
+
+        const client = createClient()
+            .use(
+                solanaRpcConnection({
+                    rpcSubscriptionsUrl: 'wss://rpc.example.com',
+                    rpcUrl: 'https://rpc.example.com',
+                }),
+            )
+            .use(mobileWallet({ chain: CHAIN, identity: IDENTITY, store }))
+            .use(rpcTransactionPlanner({ estimateResourceLimits: false }))
+            .use(planAndSendTransactions());
+        await store.persist(createExpectedAuthorization());
+
+        const result = await client.sendTransaction([getAddMemoInstruction({ memo: 'Wallet UI' })]);
+
+        expect(fetch).toHaveBeenCalledTimes(1);
+        expect(wallet.authorize).toHaveBeenCalledWith({
+            auth_token: 'cached-auth-token',
+            chain: CHAIN,
+            identity: IDENTITY,
+        });
+        expect(signAndSendTransactions).toHaveBeenCalledWith({
+            minContextSlot: 42,
+            transactions: [expect.objectContaining({ messageBytes: expect.any(Uint8Array) })],
+        });
+        expect(result.status).toBe('successful');
+        expect(result.context.signature).toBe(getBase58Decoder().decode(SIGNATURE_BYTES));
+        expect(store.$authToken.get()).toBe('next-auth-token');
+        expect(mockTransact).toHaveBeenCalledTimes(1);
+        expect(client.payer.address).toBe(FIRST_ADDRESS);
+    });
+});

--- a/packages/react-native-kit/src/__tests__/mobile-wallet-provider-test.tsx
+++ b/packages/react-native-kit/src/__tests__/mobile-wallet-provider-test.tsx
@@ -5,6 +5,7 @@ import { createAsyncStorageCache } from '../async-storage-cache';
 import type { Cache } from '../cache';
 import type { Client } from '../client';
 import { createDefaultClient } from '../create-default-client';
+import type { MobileWalletConfig } from '../mobile-wallet';
 import { MobileWalletProvider, MobileWalletProviderContext } from '../mobile-wallet-provider';
 import { createCache } from '../test-utils/fixtures';
 import { act, renderHook } from '../test-utils/react-test-renderer';
@@ -36,9 +37,10 @@ describe('MobileWalletProvider', () => {
     });
 
     it('requires a client factory for explicit custom client types', () => {
-        expectTypeOf<Parameters<typeof MobileWalletProvider<CustomClient>>[0]>().toMatchTypeOf<{
-            createClient: (cluster: { url: string; urlWs?: string }) => CustomClient;
-        }>();
+        type CustomClientFactory = Parameters<typeof MobileWalletProvider<CustomClient>>[0]['createClient'];
+
+        expectTypeOf<CustomClientFactory>().toBeFunction();
+        expectTypeOf<Parameters<CustomClientFactory>[1]>().toEqualTypeOf<MobileWalletConfig>();
         expectTypeOf<{
             children: ReactNode;
             cluster: typeof CLUSTER;
@@ -47,7 +49,7 @@ describe('MobileWalletProvider', () => {
     });
 
     it('uses the provided cache and client factory and fetches authorization on mount', async () => {
-        expect.assertions(8);
+        expect.assertions(9);
         const cache = createCache();
         const client = createClient();
         const createClientFactory = vi.fn().mockReturnValue(client);
@@ -63,9 +65,17 @@ describe('MobileWalletProvider', () => {
             await Promise.resolve();
         });
 
-        expect(createClientFactory).toHaveBeenCalledWith(CLUSTER);
+        expect(createClientFactory).toHaveBeenCalledWith(
+            CLUSTER,
+            expect.objectContaining({
+                chain: CLUSTER.id,
+                identity: IDENTITY,
+                store: expect.objectContaining({ persist: expect.any(Function) }),
+            }),
+        );
         expect(mockCreateAsyncStorageCache).not.toHaveBeenCalled();
         expect(cache.get).toHaveBeenCalledTimes(1);
+        expect(createClientFactory.mock.calls[0][1].store).toBe(hook.result.store);
         expect(hook.result.cache).toBe(cache);
         expect(hook.result.chain).toBe(CLUSTER.id);
         expect(hook.result.client).toBe(client);
@@ -95,7 +105,14 @@ describe('MobileWalletProvider', () => {
         });
 
         expect(mockCreateAsyncStorageCache).toHaveBeenCalledTimes(1);
-        expect(createClientFactory).toHaveBeenCalledWith(CLUSTER);
+        expect(createClientFactory).toHaveBeenCalledWith(
+            CLUSTER,
+            expect.objectContaining({
+                chain: CLUSTER.id,
+                identity: IDENTITY,
+                store: expect.objectContaining({ persist: expect.any(Function) }),
+            }),
+        );
         expect(cache.get).toHaveBeenCalledTimes(1);
         expect(hook.result.cache).toBe(cache);
         expect(hook.result.client).toBe(client);

--- a/packages/react-native-kit/src/__tests__/mobile-wallet-test.ts
+++ b/packages/react-native-kit/src/__tests__/mobile-wallet-test.ts
@@ -1,0 +1,223 @@
+import type { AppIdentity } from '@solana-mobile/mobile-wallet-adapter-protocol';
+import type { ClientWithRpc, GetLatestBlockhashApi } from '@solana/kit';
+
+import { createAuthorizationStore } from '../authorization-store';
+import { mobileWallet } from '../mobile-wallet';
+import {
+    createAuthorizationResult,
+    createCache,
+    createExpectedAccount,
+    createExpectedAuthorization,
+    FIRST_ADDRESS,
+    SECOND_ADDRESS,
+    SECOND_ADDRESS_BASE64,
+} from '../test-utils/fixtures';
+
+const mockCreateTransactionPlanExecutor = vi.fn();
+const mockDecodeBase58 = vi.fn();
+const mockSignAndSendTransactionMessageWithSigners = vi.fn();
+const mockTransact = vi.fn();
+
+vi.mock('@solana-mobile/mobile-wallet-adapter-protocol-kit', () => ({
+    transact: (...args: unknown[]) => mockTransact(...args),
+}));
+
+vi.mock('@solana/kit', () => ({
+    createTransactionPlanExecutor: (...args: unknown[]) => mockCreateTransactionPlanExecutor(...args),
+    extendClient: (client: object, additions: object) =>
+        Object.defineProperties(
+            Object.defineProperties({}, Object.getOwnPropertyDescriptors(client)),
+            Object.getOwnPropertyDescriptors(additions),
+        ),
+    getAddressCodec: () => ({
+        decode: () => FIRST_ADDRESS,
+    }),
+    getBase58Decoder: () => ({
+        decode: (...args: unknown[]) => mockDecodeBase58(...args),
+    }),
+    getBase64Encoder: () => ({
+        encode: (value: string) => value,
+    }),
+    pipe: (value: unknown, ...fns: Array<(input: unknown) => unknown>) => fns.reduce((input, fn) => fn(input), value),
+    setTransactionMessageFeePayerSigner: (signer: unknown, transactionMessage: object) => ({
+        ...transactionMessage,
+        feePayerSigner: signer,
+    }),
+    setTransactionMessageLifetimeUsingBlockhash: (blockhash: unknown, transactionMessage: object) => ({
+        ...transactionMessage,
+        blockhash,
+    }),
+    signAndSendTransactionMessageWithSigners: (...args: unknown[]) =>
+        mockSignAndSendTransactionMessageWithSigners(...args),
+    signature: (value: string) => value,
+}));
+
+const CHAIN = 'solana:devnet';
+const IDENTITY = {
+    name: 'Wallet UI',
+    uri: 'https://wallet-ui.dev',
+} as AppIdentity;
+
+describe('mobileWallet', () => {
+    beforeEach(() => {
+        mockCreateTransactionPlanExecutor.mockReset();
+        mockDecodeBase58.mockReset();
+        mockSignAndSendTransactionMessageWithSigners.mockReset();
+        mockTransact.mockReset();
+
+        mockCreateTransactionPlanExecutor.mockImplementation(({ executeTransactionMessage }) => {
+            return async ({ message }: { message: object }) => {
+                const context: Record<string, unknown> = {};
+                const signature = await executeTransactionMessage(context, message);
+                return {
+                    context: { ...context, signature },
+                    kind: 'single',
+                    plannedMessage: message,
+                    planType: 'transactionPlanResult',
+                    status: 'successful',
+                };
+            };
+        });
+        mockDecodeBase58.mockReturnValue('encoded-signature');
+    });
+
+    it('requires an RPC capability', () => {
+        const store = createAuthorizationStore({ cache: createCache() });
+
+        expect(() => mobileWallet({ chain: CHAIN, identity: IDENTITY, store })({} as never)).toThrow(
+            'An RPC instance is required on the client before using the mobile wallet plugin.',
+        );
+    });
+
+    it('fails with an actionable error when no account is authorized', () => {
+        const store = createAuthorizationStore({ cache: createCache() });
+        const client = createPluginClient(store);
+
+        expect(() => client.payer).toThrow('Call `connect()` before requesting the mobile wallet payer.');
+    });
+
+    it('connects and disconnects without React', async () => {
+        expect.assertions(5);
+        const store = createAuthorizationStore({ cache: createCache() });
+        const wallet = {
+            authorize: vi.fn().mockResolvedValue(createAuthorizationResult()),
+        };
+        mockTransact.mockImplementation(async callback => await callback(wallet));
+        const client = createPluginClient(store);
+
+        const account = await client.wallet.connect();
+
+        expect(account.address).toBe(FIRST_ADDRESS);
+        expect(client.payer.address).toBe(FIRST_ADDRESS);
+        expect(store.$authToken.get()).toBe('next-auth-token');
+
+        await client.wallet.disconnect();
+
+        expect(store.$authToken.get()).toBeUndefined();
+        expect(() => client.payer).toThrow('Call `connect()` before requesting the mobile wallet payer.');
+    });
+
+    it('resolves the current payer lazily and notifies payer subscribers', async () => {
+        expect.assertions(4);
+        const store = createAuthorizationStore({ cache: createCache() });
+        const client = createPluginClient(store);
+        const listener = vi.fn();
+        const unsubscribe = client.subscribeToPayer(listener);
+
+        await store.persist(createExpectedAuthorization());
+
+        expect(listener).toHaveBeenCalledTimes(1);
+        expect(client.payer.address).toBe(FIRST_ADDRESS);
+
+        await store.persist(null);
+
+        expect(listener).toHaveBeenCalledTimes(2);
+        expect(() => client.payer).toThrow('Call `connect()` before requesting the mobile wallet payer.');
+        unsubscribe();
+    });
+
+    it('returns a stable payer reference until the selected account changes', async () => {
+        expect.assertions(3);
+        const store = createAuthorizationStore({ cache: createCache() });
+        await store.persist(createExpectedAuthorization());
+        const client = createPluginClient(store);
+        const payer = client.payer;
+
+        expect(client.payer).toBe(payer);
+
+        const secondAccount = createExpectedAccount({
+            address: SECOND_ADDRESS,
+            addressBase64: SECOND_ADDRESS_BASE64,
+        });
+        await store.persist(createExpectedAuthorization({ accounts: [secondAccount] }));
+
+        expect(client.payer).not.toBe(payer);
+        expect(client.payer.address).toBe(SECOND_ADDRESS);
+    });
+
+    it('authorizes and sends transaction plans through MWA', async () => {
+        expect.assertions(8);
+        const store = createAuthorizationStore({ cache: createCache() });
+        await store.persist(createExpectedAuthorization());
+        const signAndSendTransactions = vi.fn().mockResolvedValue([new Uint8Array([1, 2, 3])]);
+        const wallet = {
+            authorize: vi.fn().mockResolvedValue(createAuthorizationResult()),
+            signAndSendTransactions,
+        };
+        mockTransact.mockImplementation(async callback => await callback(wallet));
+        mockSignAndSendTransactionMessageWithSigners.mockImplementation(async transactionMessage => {
+            const [signature] = await transactionMessage.feePayerSigner.signAndSendTransactions([transactionMessage]);
+            return signature;
+        });
+        const client = createPluginClient(store);
+
+        const result = await client.transactionPlanExecutor({ message: { id: 'planned-message' } } as never);
+
+        expect(client.rpc.getLatestBlockhash).toHaveBeenCalledTimes(1);
+        expect(wallet.authorize).toHaveBeenCalledWith({
+            auth_token: 'cached-auth-token',
+            chain: CHAIN,
+            identity: IDENTITY,
+        });
+        expect(signAndSendTransactions).toHaveBeenCalledWith({
+            minContextSlot: 42,
+            transactions: [
+                expect.objectContaining({
+                    blockhash: expect.objectContaining({ blockhash: 'latest-blockhash' }),
+                    feePayerSigner: expect.objectContaining({ address: FIRST_ADDRESS }),
+                    id: 'planned-message',
+                }),
+            ],
+        });
+        expect(mockDecodeBase58).toHaveBeenCalledWith(new Uint8Array([1, 2, 3]));
+        expect(result).toEqual(
+            expect.objectContaining({
+                context: expect.objectContaining({
+                    message: expect.objectContaining({ id: 'planned-message' }),
+                    signature: 'encoded-signature',
+                }),
+                status: 'successful',
+            }),
+        );
+        expect(store.$authToken.get()).toBe('next-auth-token');
+        expect(mockTransact).toHaveBeenCalledTimes(1);
+        expect(mockSignAndSendTransactionMessageWithSigners).toHaveBeenCalledTimes(1);
+    });
+});
+
+function createPluginClient(store: ReturnType<typeof createAuthorizationStore>) {
+    const rpc = {
+        getLatestBlockhash: vi.fn(() => ({
+            send: vi.fn().mockResolvedValue({
+                context: { slot: 42n },
+                value: {
+                    blockhash: 'latest-blockhash',
+                    lastValidBlockHeight: 1n,
+                },
+            }),
+        })),
+    };
+    return mobileWallet({ chain: CHAIN, identity: IDENTITY, store })({
+        rpc,
+    } as unknown as ClientWithRpc<GetLatestBlockhashApi>);
+}

--- a/packages/react-native-kit/src/__tests__/mobile-wallet-typetest.ts
+++ b/packages/react-native-kit/src/__tests__/mobile-wallet-typetest.ts
@@ -1,0 +1,32 @@
+import { createClient } from '@solana/kit';
+import { planAndSendTransactions } from '@solana/kit-plugin-instruction-plan';
+import { rpcTransactionPlanner, solanaRpcConnection } from '@solana/kit-plugin-rpc';
+
+import { createAuthorizationStore } from '../authorization-store';
+import type { BaseClient } from '../client';
+import { mobileWallet } from '../mobile-wallet';
+import { createCache } from '../test-utils/fixtures';
+
+describe('mobileWallet types', () => {
+    it('composes with the granular Kit RPC plugins', () => {
+        const client = createClient()
+            .use(solanaRpcConnection({ rpcUrl: 'https://api.devnet.solana.com' }))
+            .use(
+                mobileWallet({
+                    chain: 'solana:devnet',
+                    identity: { name: 'Wallet UI', uri: 'https://wallet-ui.dev' },
+                    store: createAuthorizationStore({ cache: createCache() }),
+                }),
+            )
+            .use(rpcTransactionPlanner({ estimateResourceLimits: false }))
+            .use(planAndSendTransactions());
+
+        expectTypeOf(client).toMatchTypeOf<BaseClient>();
+        expectTypeOf(client.payer.signAndSendTransactions).toBeFunction();
+        expectTypeOf(client.sendTransaction).toBeFunction();
+        expectTypeOf(client.sendTransactions).toBeFunction();
+        expectTypeOf(client.subscribeToPayer).toBeFunction();
+        expectTypeOf(client.wallet.connect).toBeFunction();
+        expectTypeOf(client.wallet.disconnect).toBeFunction();
+    });
+});

--- a/packages/react-native-kit/src/authorize-mobile-wallet-session.ts
+++ b/packages/react-native-kit/src/authorize-mobile-wallet-session.ts
@@ -1,0 +1,44 @@
+import {
+    AppIdentity,
+    AuthorizeAPI,
+    AuthorizationResult,
+    AuthToken,
+    Chain,
+    SolanaMobileWalletAdapterProtocolError,
+    SolanaMobileWalletAdapterProtocolErrorCode,
+} from '@solana-mobile/mobile-wallet-adapter-protocol';
+
+import { assertValidIdentityUri } from './assert-valid-identity-uri';
+import type { WalletAuthorization } from './use-authorization';
+
+export type AuthorizeMobileWalletSessionConfig = Readonly<{
+    authToken?: AuthToken;
+    chain: Chain;
+    handleAuthorizationResult: (authorizationResult: AuthorizationResult) => Promise<WalletAuthorization>;
+    identity: AppIdentity;
+}>;
+
+export async function authorizeMobileWalletSession(
+    { authToken, chain, handleAuthorizationResult, identity }: AuthorizeMobileWalletSessionConfig,
+    wallet: AuthorizeAPI,
+) {
+    assertValidIdentityUri(identity);
+
+    try {
+        const authorizationResult = await wallet.authorize({
+            auth_token: authToken,
+            chain,
+            identity,
+        });
+        return (await handleAuthorizationResult(authorizationResult)).selectedAccount;
+    } catch (error) {
+        if (
+            error instanceof SolanaMobileWalletAdapterProtocolError &&
+            error.code === SolanaMobileWalletAdapterProtocolErrorCode.ERROR_AUTHORIZATION_FAILED
+        ) {
+            const authorizationResult = await wallet.authorize({ chain, identity });
+            return (await handleAuthorizationResult(authorizationResult)).selectedAccount;
+        }
+        throw error;
+    }
+}

--- a/packages/react-native-kit/src/index.ts
+++ b/packages/react-native-kit/src/index.ts
@@ -1,6 +1,7 @@
 export * from './authorization-store';
 export * from './cache';
 export * from './convert-sign-in-result';
+export * from './mobile-wallet';
 export * from './mobile-wallet-provider';
 export * from './use-authorization';
 export * from './use-mobile-wallet';

--- a/packages/react-native-kit/src/mobile-wallet-provider.tsx
+++ b/packages/react-native-kit/src/mobile-wallet-provider.tsx
@@ -1,14 +1,18 @@
 import { AppIdentity } from '@solana-mobile/mobile-wallet-adapter-protocol';
 import { SolanaCluster } from '@wallet-ui/core';
-import React, { createContext, type ReactNode, useEffect, useMemo, useState } from 'react';
+import React, { createContext, type ReactNode, useEffect, useMemo, useRef, useState } from 'react';
 
 import { createAsyncStorageCache } from './async-storage-cache';
 import { AuthorizationStore, createAuthorizationStore } from './authorization-store';
 import type { BaseClient, Client } from './client';
 import { createDefaultClient } from './create-default-client';
+import type { MobileWalletConfig } from './mobile-wallet';
 import { WalletAuthorization, WalletAuthorizationCache, WalletAuthorizationProps } from './use-authorization';
 
-type ClientFactory<TClient extends BaseClient> = (cluster: { url: string; urlWs?: string }) => TClient;
+type ClientFactory<TClient extends BaseClient> = (
+    cluster: { url: string; urlWs?: string },
+    mobileWalletConfig: MobileWalletConfig,
+) => TClient;
 type MobileWalletProviderClientProps<TClient extends BaseClient> = Client extends TClient
     ? { createClient?: ClientFactory<TClient> }
     : { createClient: ClientFactory<TClient> };
@@ -34,13 +38,22 @@ export function MobileWalletProvider<TClient extends BaseClient = Client>({
     createClient,
     identity,
 }: MobileWalletProviderProps<TClient>) {
-    const cache = useMemo(() => userCache ?? createAsyncStorageCache<WalletAuthorization>(), [userCache]);
+    // Built lazily and kept in a ref so the default cache is created at most once, and only when no cache is provided.
+    const defaultCache = useRef<WalletAuthorizationCache | undefined>(undefined);
+    const cache = userCache ?? (defaultCache.current ??= createAsyncStorageCache<WalletAuthorization>());
+    // Rebuild the store when `cache` changes so its state never diverges from the cache it reads and writes.
+    const [storeState, setStoreState] = useState(() => ({ cache, store: createAuthorizationStore({ cache }) }));
+    if (storeState.cache !== cache) {
+        setStoreState({ cache, store: createAuthorizationStore({ cache }) });
+    }
+    const { store } = storeState;
+    const mobileWalletConfig = useMemo(() => ({ chain: cluster.id, identity, store }), [cluster.id, identity, store]);
     const client = useMemo(
-        () => (createClient ? createClient(cluster) : createDefaultClient(cluster)),
-        [createClient, cluster],
+        () => (createClient ? createClient(cluster, mobileWalletConfig) : createDefaultClient(cluster)),
+        // Keyed on the cluster fields the factories read, so an inline `cluster` literal does not rebuild the client
+        // on every render. `cluster.id` reaches the factory through `mobileWalletConfig`.
+        [createClient, cluster.url, cluster.urlWs, mobileWalletConfig],
     );
-
-    const [store] = useState(() => createAuthorizationStore({ cache }));
 
     useEffect(() => {
         store.fetch().catch(console.error);

--- a/packages/react-native-kit/src/mobile-wallet.ts
+++ b/packages/react-native-kit/src/mobile-wallet.ts
@@ -1,0 +1,139 @@
+import { transact } from '@solana-mobile/mobile-wallet-adapter-protocol-kit';
+import {
+    ClientWithRpc,
+    ClientWithSubscribeToPayer,
+    createTransactionPlanExecutor,
+    extendClient,
+    getBase58Decoder,
+    GetLatestBlockhashApi,
+    pipe,
+    setTransactionMessageFeePayerSigner,
+    setTransactionMessageLifetimeUsingBlockhash,
+    signAndSendTransactionMessageWithSigners,
+    signature,
+    TransactionPlanExecutor,
+    TransactionSendingSigner,
+} from '@solana/kit';
+
+import { authorizeMobileWalletSession } from './authorize-mobile-wallet-session';
+import { getAuthorizationFromAuthorizationResult } from './get-authorization-from-authorization-result';
+import type { Account, WalletAuthorizationProps } from './use-authorization';
+
+export type MobileWalletConfig = Readonly<Pick<WalletAuthorizationProps, 'chain' | 'identity' | 'store'>>;
+
+export type ClientWithMobileWallet = ClientWithSubscribeToPayer & {
+    readonly payer: TransactionSendingSigner;
+    readonly transactionPlanExecutor: TransactionPlanExecutor;
+    readonly wallet: Readonly<{
+        connect: () => Promise<Account>;
+        disconnect: () => Promise<void>;
+    }>;
+};
+
+const decoder = getBase58Decoder();
+
+export function mobileWallet(config: MobileWalletConfig) {
+    return <T extends ClientWithRpc<GetLatestBlockhashApi>>(client: T) => {
+        if (!client.rpc) {
+            throw new Error('An RPC instance is required on the client before using the mobile wallet plugin.');
+        }
+
+        const transactionPlanExecutor = createTransactionPlanExecutor({
+            executeTransactionMessage: async (context, transactionMessage, executorConfig) => {
+                executorConfig?.abortSignal?.throwIfAborted();
+                const {
+                    context: { slot: minContextSlot },
+                    value: latestBlockhash,
+                } = await client.rpc.getLatestBlockhash().send(executorConfig);
+                const signer = createMobileWalletTransactionSigner(config, minContextSlot);
+                const message = pipe(
+                    transactionMessage,
+                    tx => setTransactionMessageFeePayerSigner(signer, tx),
+                    tx => setTransactionMessageLifetimeUsingBlockhash(latestBlockhash, tx),
+                );
+                context.message = message;
+                const signatureBytes = await signAndSendTransactionMessageWithSigners(message, executorConfig);
+                return signature(decoder.decode(signatureBytes));
+            },
+        });
+
+        // Cached per selected account so repeated reads return the same reference. `subscribeToPayer` + `payer` is a
+        // `useSyncExternalStore` pair; a fresh object on every read would re-render without end.
+        let cachedAccount: Account | undefined;
+        let cachedPayer: TransactionSendingSigner | undefined;
+
+        const additions = {
+            subscribeToPayer: (listener: () => void) => config.store.$selectedAccount.listen(() => listener()),
+            transactionPlanExecutor,
+            wallet: {
+                connect: async () => await transact(async wallet => await authorizeWithStore(config, wallet)),
+                disconnect: async () => await config.store.persist(null),
+            },
+        } as Record<string, unknown>;
+        Object.defineProperty(additions, 'payer', {
+            configurable: true,
+            enumerable: false,
+            get: () => {
+                const account = config.store.$selectedAccount.get();
+                if (!cachedPayer || cachedAccount !== account) {
+                    cachedPayer = createMobileWalletTransactionSigner(config);
+                    cachedAccount = account;
+                }
+                return cachedPayer;
+            },
+        });
+
+        return extendClient(client, additions as ClientWithMobileWallet);
+    };
+}
+
+function createMobileWalletTransactionSigner(
+    config: MobileWalletConfig,
+    minContextSlot?: bigint,
+): TransactionSendingSigner {
+    const account = config.store.$selectedAccount.get();
+    if (!account) {
+        throw new Error(
+            'No mobile wallet account is authorized. Call `connect()` before requesting the mobile wallet payer.',
+        );
+    }
+
+    return {
+        address: account.address,
+        signAndSendTransactions: async (transactions, signerConfig) => {
+            signerConfig?.abortSignal?.throwIfAborted();
+            const signatures = await transact(async wallet => {
+                await authorizeWithStore(config, wallet);
+                signerConfig?.abortSignal?.throwIfAborted();
+                return await wallet.signAndSendTransactions({
+                    ...(minContextSlot == null ? {} : { minContextSlot: Number(minContextSlot) }),
+                    transactions: [...transactions],
+                });
+            });
+            signerConfig?.abortSignal?.throwIfAborted();
+            return signatures;
+        },
+    };
+}
+
+async function authorizeWithStore(
+    config: MobileWalletConfig,
+    wallet: Parameters<typeof authorizeMobileWalletSession>[1],
+) {
+    return await authorizeMobileWalletSession(
+        {
+            authToken: config.store.$authToken.get(),
+            chain: config.chain,
+            handleAuthorizationResult: async authorizationResult => {
+                const authorization = getAuthorizationFromAuthorizationResult(
+                    authorizationResult,
+                    config.store.$selectedAccount.get(),
+                );
+                await config.store.persist(authorization);
+                return authorization;
+            },
+            identity: config.identity,
+        },
+        wallet,
+    );
+}

--- a/packages/react-native-kit/src/use-authorization.ts
+++ b/packages/react-native-kit/src/use-authorization.ts
@@ -15,6 +15,7 @@ import { WalletIcon } from '@wallet-standard/core';
 import { useCallback, useMemo } from 'react';
 
 import { assertValidIdentityUri } from './assert-valid-identity-uri';
+import { authorizeMobileWalletSession } from './authorize-mobile-wallet-session';
 import { AuthorizationStore } from './authorization-store';
 import { Cache } from './cache';
 import { convertSignInResult, SignInOutput } from './convert-sign-in-result';
@@ -55,30 +56,9 @@ export function useAuthorization({ chain, identity, store }: WalletAuthorization
     );
 
     const authorizeSession = useCallback(
-        async (wallet: AuthorizeAPI) => {
-            assertValidIdentityUri(identity);
-            try {
-                const authorizationResult = await wallet.authorize({
-                    auth_token: authToken,
-                    chain,
-                    identity,
-                });
-                return (await handleAuthorizationResult(authorizationResult)).selectedAccount;
-            } catch (error) {
-                if (
-                    error instanceof SolanaMobileWalletAdapterProtocolError &&
-                    error.code === SolanaMobileWalletAdapterProtocolErrorCode.ERROR_AUTHORIZATION_FAILED
-                ) {
-                    const retryResult = await wallet.authorize({
-                        chain,
-                        identity,
-                    });
-                    return (await handleAuthorizationResult(retryResult)).selectedAccount;
-                }
-                throw error;
-            }
-        },
-        [authToken, chain, identity, handleAuthorizationResult],
+        async (wallet: AuthorizeAPI) =>
+            await authorizeMobileWalletSession({ authToken, chain, handleAuthorizationResult, identity }, wallet),
+        [authToken, chain, handleAuthorizationResult, identity],
     );
 
     const authorizeSessionWithSignIn = useCallback(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -765,16 +765,16 @@ importers:
         version: 2.2.8(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.0.9)(utf-8-validate@5.0.10))(@types/react@19.2.14)(bufferutil@4.0.9)(react@19.1.0)(utf-8-validate@5.0.10))(typescript@6.0.3)
       '@solana-mobile/mobile-wallet-adapter-protocol-kit':
         specifier: ^0.3.1
-        version: 0.3.1(@solana/kit@6.1.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@5.0.10))(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.0.9)(utf-8-validate@5.0.10))(@types/react@19.2.14)(bufferutil@4.0.9)(react@19.1.0)(utf-8-validate@5.0.10))(typescript@6.0.3)
+        version: 0.3.1(@solana/kit@7.0.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@5.0.10))(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.0.9)(utf-8-validate@5.0.10))(@types/react@19.2.14)(bufferutil@4.0.9)(react@19.1.0)(utf-8-validate@5.0.10))(typescript@6.0.3)
       '@solana-program/memo':
-        specifier: ^0.11.0
-        version: 0.11.0(@solana/kit@6.1.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@5.0.10))
+        specifier: ^0.12.0
+        version: 0.12.0(@solana/kit@7.0.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@5.0.10))
       '@solana/kit':
-        specifier: ^6.1.0 || ^7.0.0
-        version: 6.1.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@5.0.10)
+        specifier: ^7.0.0
+        version: 7.0.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@5.0.10)
       '@solana/react':
-        specifier: ^6.1.0
-        version: 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.2.3(react@19.1.0))(react@19.1.0)(typescript@6.0.3)
+        specifier: ^7.0.0
+        version: 7.0.0(@solana/kit@7.0.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@5.0.10))(@tanstack/react-query@5.100.1(react@19.1.0))(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.2.3(react@19.1.0))(react@19.1.0)(typescript@6.0.3)
       '@solana/wallet-standard-features':
         specifier: 1.3.0
         version: 1.3.0
@@ -794,6 +794,12 @@ importers:
         specifier: ^1.2.0
         version: 1.2.0
     devDependencies:
+      '@solana/kit-plugin-instruction-plan':
+        specifier: ^0.13.0
+        version: 0.13.0(@solana/kit@7.0.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@5.0.10))
+      '@solana/kit-plugin-rpc':
+        specifier: ^0.16.0
+        version: 0.16.0(@solana/kit@7.0.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@5.0.10))
       '@types/react':
         specifier: ^19.1.17
         version: 19.2.14
@@ -4694,6 +4700,11 @@ packages:
     peerDependencies:
       '@solana/kit': ^6.0.0
 
+  '@solana-program/memo@0.12.0':
+    resolution: {integrity: sha512-sOY182HLdngvlfjg1n1e8mXIz5nP4kNZRWBT33mk6SJsMXwUahL5w/XwaeQ8cj8PYPf2FiH0IpZ2tbZW6f0SBQ==}
+    peerDependencies:
+      '@solana/kit': ^7.0.0
+
   '@solana-program/system@0.13.0':
     resolution: {integrity: sha512-Id6QQxCG7ByImXPD5X/c3Ag2kySD+49aJ9waIkfxyUFyokhMQgxYQAx2rKuaygaBlaBQY6VVfBS46pqxZV+99A==}
     peerDependencies:
@@ -5172,6 +5183,22 @@ packages:
       react:
         optional: true
 
+  '@solana/react@7.0.0':
+    resolution: {integrity: sha512-+BDWCUdFpRkD+zGV2iiyEVWrF9AWw7tQsdiqHHAZa8Td/7CLYw+H8IjtuapMYNK2RZQhqKrSK9OWLE8rh63Qdg==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      '@solana/kit': 7.0.0
+      '@tanstack/react-query': ^5.0.0
+      react: '>=18'
+      swr: ^2.0.0
+    peerDependenciesMeta:
+      '@tanstack/react-query':
+        optional: true
+      react:
+        optional: true
+      swr:
+        optional: true
+
   '@solana/rpc-api@6.1.0':
     resolution: {integrity: sha512-+hO5+kZjJHuUNATUQxlJ1+ztXFkgn1j46zRwt3X7kF+VHkW3wsQ7up0JTS+Xsacmkrj1WKfymQweq8JTrsAG8A==}
     engines: {node: '>=20.18.0'}
@@ -5518,6 +5545,10 @@ packages:
   '@solana/wallet-standard-features@1.3.0':
     resolution: {integrity: sha512-ZhpZtD+4VArf6RPitsVExvgkF+nGghd1rzPjd97GmBximpnt1rsUxMOEyoIEuH3XBxPyNB6Us7ha7RHWQR+abg==}
     engines: {node: '>=16'}
+
+  '@solana/wallet-standard-features@1.4.0':
+    resolution: {integrity: sha512-f0tAdqwM2aL6CiFbIgt9h5zKFp+mgY/iNGwoxPMTj9VSTeQj7d1GGSmWhZw0XWoZ4N/1tnKTKmYFq+Dyq08jRw==}
+    engines: {node: '>=22'}
 
   '@solana/wallet-standard-util@1.1.2':
     resolution: {integrity: sha512-rUXFNP4OY81Ddq7qOjQV4Kmkozx4wjYAxljvyrqPx8Ycz0FYChG/hQVWqvgpK3sPsEaO/7ABG1NOACsyAKWNOA==}
@@ -5991,6 +6022,11 @@ packages:
   '@wallet-standard/errors@0.1.1':
     resolution: {integrity: sha512-V8Ju1Wvol8i/VDyQOHhjhxmMVwmKiwyxUZBnHhtiPZJTWY0U/Shb2iEWyGngYEbAkp2sGTmEeNX1tVyGR7PqNw==}
     engines: {node: '>=16'}
+    hasBin: true
+
+  '@wallet-standard/errors@0.1.2':
+    resolution: {integrity: sha512-oEzKUqJefKby6wcIvaJgrSEe/uNn/rnqkJ0P/85K+h0i5Tdo9E3L22VWq/j5K1e8hHMnZd6LgaIr8m/Wn7X/Ng==}
+    engines: {node: '>=22'}
     hasBin: true
 
   '@wallet-standard/experimental-features@0.2.0':
@@ -15485,10 +15521,10 @@ snapshots:
       '@sinonjs/commons': 3.0.1
     optional: true
 
-  '@solana-mobile/mobile-wallet-adapter-protocol-kit@0.3.1(@solana/kit@6.1.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@5.0.10))(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.0.9)(utf-8-validate@5.0.10))(@types/react@19.2.14)(bufferutil@4.0.9)(react@19.1.0)(utf-8-validate@5.0.10))(typescript@6.0.3)':
+  '@solana-mobile/mobile-wallet-adapter-protocol-kit@0.3.1(@solana/kit@7.0.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@5.0.10))(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.0.9)(utf-8-validate@5.0.10))(@types/react@19.2.14)(bufferutil@4.0.9)(react@19.1.0)(utf-8-validate@5.0.10))(typescript@6.0.3)':
     dependencies:
       '@solana-mobile/mobile-wallet-adapter-protocol': 2.2.8(fastestsmallesttextencoderdecoder@1.0.22)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.0.9)(utf-8-validate@5.0.10))(@types/react@19.2.14)(bufferutil@4.0.9)(react@19.1.0)(utf-8-validate@5.0.10))(typescript@6.0.3)
-      '@solana/kit': 6.1.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@5.0.10)
+      '@solana/kit': 7.0.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@5.0.10)
       '@solana/transaction-messages': 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       '@solana/transactions': 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
       bs58: 6.0.0
@@ -15536,6 +15572,10 @@ snapshots:
   '@solana-program/memo@0.11.0(@solana/kit@6.1.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@5.0.10))':
     dependencies:
       '@solana/kit': 6.1.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@5.0.10)
+
+  '@solana-program/memo@0.12.0(@solana/kit@7.0.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@5.0.10))':
+    dependencies:
+      '@solana/kit': 7.0.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@5.0.10)
 
   '@solana-program/system@0.13.0(@solana/kit@7.0.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@5.0.10))':
     dependencies:
@@ -16088,6 +16128,28 @@ snapshots:
       - react-dom
       - typescript
 
+  '@solana/react@7.0.0(@solana/kit@7.0.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@5.0.10))(@tanstack/react-query@5.100.1(react@19.1.0))(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.2.3(react@19.1.0))(react@19.1.0)(typescript@6.0.3)':
+    dependencies:
+      '@solana/kit': 7.0.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)(utf-8-validate@5.0.10)
+      '@solana/promises': 7.0.0(typescript@6.0.3)
+      '@solana/signers': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/subscribable': 7.0.0(typescript@6.0.3)
+      '@solana/transaction-messages': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/transactions': 7.0.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
+      '@solana/wallet-standard-features': 1.4.0
+      '@wallet-standard/base': 1.1.0
+      '@wallet-standard/errors': 0.1.2
+      '@wallet-standard/react': 1.0.1(react-dom@19.2.3(react@19.1.0))(react@19.1.0)
+      '@wallet-standard/ui': 1.0.1
+      '@wallet-standard/ui-registry': 1.0.1
+    optionalDependencies:
+      '@tanstack/react-query': 5.100.1(react@19.1.0)
+      react: 19.1.0
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+      - react-dom
+      - typescript
+
   '@solana/rpc-api@6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)':
     dependencies:
       '@solana/addresses': 6.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@6.0.3)
@@ -16576,6 +16638,11 @@ snapshots:
       '@wallet-standard/base': 1.1.0
       '@wallet-standard/features': 1.1.0
 
+  '@solana/wallet-standard-features@1.4.0':
+    dependencies:
+      '@wallet-standard/base': 1.1.0
+      '@wallet-standard/features': 1.1.0
+
   '@solana/wallet-standard-util@1.1.2':
     dependencies:
       '@noble/curves': 1.9.7
@@ -16764,6 +16831,12 @@ snapshots:
       vite: 7.3.2(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.8.3)
 
   '@tanstack/query-core@5.100.1': {}
+
+  '@tanstack/react-query@5.100.1(react@19.1.0)':
+    dependencies:
+      '@tanstack/query-core': 5.100.1
+      react: 19.1.0
+    optional: true
 
   '@tanstack/react-query@5.100.1(react@19.2.1)':
     dependencies:
@@ -17127,6 +17200,11 @@ snapshots:
       '@wallet-standard/wallet': 1.1.0
 
   '@wallet-standard/errors@0.1.1':
+    dependencies:
+      chalk: 5.6.2
+      commander: 13.1.0
+
+  '@wallet-standard/errors@0.1.2':
     dependencies:
       chalk: 5.6.2
       commander: 13.1.0


### PR DESCRIPTION
Add a Kit 7 mobileWallet client plugin with a lazy payer backed by the authorization store and an MWA-routed transaction plan executor.

Pass the provider mobile-wallet config to custom client factories, add headless connect and disconnect support, and document composition with granular Kit RPC plugins.

Cover disconnected, account-change, authorization, transaction submission, provider integration, and real plugin-chain behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Mobile Wallet Adapter support for React Native applications.
  * Added wallet connection and disconnection controls with persisted authorization sessions.
  * Added wallet-routed transaction execution, including automatic payer assignment and signature handling.
  * Added support for headless wallet session management and lazy payer access.
* **Documentation**
  * Expanded setup and usage guidance for mobile wallet integration, providers, authorization, and transactions.
* **Chores**
  * Updated Solana Kit dependencies for the new integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->