### PR TITLE
docs: update starter template generators

### DIFF
--- a/docs/src/content/docs/react-native/getting-started.mdx
+++ b/docs/src/content/docs/react-native/getting-started.mdx
@@ -41,26 +41,29 @@ Starter templates are available for both React Native packages.
 ### Kit
 
 <PackageManagerTabs
-    npm={`npx create-solana-dapp@latest -t kit-expo-minimal
-npx create-solana-dapp@latest -t kit-expo-uniwind`}
-    pnpm={`pnpm dlx create-solana-dapp@latest -t kit-expo-minimal
-pnpm dlx create-solana-dapp@latest -t kit-expo-uniwind`}
-    bun={`bunx create-solana-dapp@latest -t kit-expo-minimal
-bunx create-solana-dapp@latest -t kit-expo-uniwind`}
+    npm={`npx solana-mobile@latest create -t expo-kit-anchor
+npx solana-mobile@latest create -t expo-kit-minimal
+npx solana-mobile@latest create -t expo-kit-uniwind`}
+    pnpm={`pnpm dlx solana-mobile@latest create -t expo-kit-anchor
+pnpm dlx solana-mobile@latest create -t expo-kit-minimal
+pnpm dlx solana-mobile@latest create -t expo-kit-uniwind`}
+    bun={`bunx solana-mobile@latest create -t expo-kit-anchor
+bunx solana-mobile@latest create -t expo-kit-minimal
+bunx solana-mobile@latest create -t expo-kit-uniwind`}
 />
 
 ### Web3.js
 
 <PackageManagerTabs
-    npm={`npx create-solana-dapp@latest -t web3js-expo-minimal
-npx create-solana-dapp@latest -t web3js-expo
-npx create-solana-dapp@latest -t web3js-expo-paper`}
-    pnpm={`pnpm dlx create-solana-dapp@latest -t web3js-expo-minimal
-pnpm dlx create-solana-dapp@latest -t web3js-expo
-pnpm dlx create-solana-dapp@latest -t web3js-expo-paper`}
-    bun={`bunx create-solana-dapp@latest -t web3js-expo-minimal
-bunx create-solana-dapp@latest -t web3js-expo
-bunx create-solana-dapp@latest -t web3js-expo-paper`}
+    npm={`npx solana-mobile@latest create -t expo-web3js-anchor
+npx solana-mobile@latest create -t expo-web3js-minimal
+npx solana-mobile@latest create -t expo-web3js-uniwind`}
+    pnpm={`pnpm dlx solana-mobile@latest create -t expo-web3js-anchor
+pnpm dlx solana-mobile@latest create -t expo-web3js-minimal
+pnpm dlx solana-mobile@latest create -t expo-web3js-uniwind`}
+    bun={`bunx solana-mobile@latest create -t expo-web3js-anchor
+bunx solana-mobile@latest create -t expo-web3js-minimal
+bunx solana-mobile@latest create -t expo-web3js-uniwind`}
 />
 
 ## Setup guides

--- a/docs/src/content/docs/react/getting-started.mdx
+++ b/docs/src/content/docs/react/getting-started.mdx
@@ -10,28 +10,22 @@ import PackageManagerTabs from '../../../components/docs/PackageManagerTabs.astr
 
 The fastest path is to start from a template. That gives you a working app structure, styling setup, and Wallet UI already wired in.
 
-### Next.js and Tailwind CSS
-
-Basic Next.js app with Tailwind, gill and Wallet UI.
-
-Use templates `gill-next-tailwind-basic` or `gill-next-tailwind-counter` to generate a starting point with Wallet UI and the surrounding app scaffolding in place.
-
-<PackageManagerTabs
-    npm="npx create-solana-dapp@latest -t gill-next-tailwind"
-    pnpm="pnpm dlx create-solana-dapp@latest -t gill-next-tailwind"
-    bun="bunx create-solana-dapp@latest -t gill-next-tailwind"
-/>
-
 ### React with Vite and Tailwind CSS
 
-Basic React app with Vite, Tailwind, gill and Wallet UI.
+React apps with Vite, TypeScript, Tailwind CSS, Wallet UI, and Solana Kit.
 
-Use templates `gill-react-vite-tailwind-basic` or `gill-react-vite-tailwind-counter` to generate a starting point with Wallet UI and the surrounding app scaffolding in place.
+Use `bun-react-vite-solana-kit` for a basic app, or choose `quasar-react-counter` or `quasar-react-escrow` for an app with an example Quasar program.
 
 <PackageManagerTabs
-    npm="npx create-solana-dapp@latest -t gill-react-vite-tailwind"
-    pnpm="pnpm dlx create-solana-dapp@latest -t gill-react-vite-tailwind"
-    bun="bunx create-solana-dapp@latest -t gill-react-vite-tailwind"
+    npm={`npx create-seed@latest -t bun-react-vite-solana-kit
+npx create-seed@latest -t quasar-react-counter
+npx create-seed@latest -t quasar-react-escrow`}
+    pnpm={`pnpm dlx create-seed@latest -t bun-react-vite-solana-kit
+pnpm dlx create-seed@latest -t quasar-react-counter
+pnpm dlx create-seed@latest -t quasar-react-escrow`}
+    bun={`bunx create-seed@latest -t bun-react-vite-solana-kit
+bunx create-seed@latest -t quasar-react-counter
+bunx create-seed@latest -t quasar-react-escrow`}
 />
 
 ## Framework guide


### PR DESCRIPTION
Use create-seed for the React templates and list the available Solana Kit and Quasar starters. Use solana-mobile create for the React Native Kit and web3.js templates.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated React Native starter instructions with current `solana-mobile` templates for Kit, Web3.js, Anchor, minimal, and Uniwind projects.
  * Replaced outdated React template guidance with React, Vite, TypeScript, Tailwind CSS, Wallet UI, and Solana Kit options.
  * Added npm, pnpm, and bun commands for the available starter templates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->